### PR TITLE
[LMS-378] update v3.3.0-a sample data to include digital equity data

### DIFF
--- a/Descriptors/AbsenceEventCategoryDescriptor.xml
+++ b/Descriptors/AbsenceEventCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AbsenceEventCategoryDescriptor>
 		<CodeValue>Bereavement</CodeValue>
 		<ShortDescription>Bereavement</ShortDescription>

--- a/Descriptors/AcademicHonorCategoryDescriptor.xml
+++ b/Descriptors/AcademicHonorCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AcademicHonorCategoryDescriptor>
 		<CodeValue>Attendance award</CodeValue>
 		<ShortDescription>Attendance award</ShortDescription>

--- a/Descriptors/AcademicSubjectDescriptor.xml
+++ b/Descriptors/AcademicSubjectDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AcademicSubjectDescriptor>
 		<CodeValue>Composite</CodeValue>
 		<ShortDescription>Composite</ShortDescription>

--- a/Descriptors/AccommodationDescriptor.xml
+++ b/Descriptors/AccommodationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AccommodationDescriptor>
 		<CodeValue>504 accommodation</CodeValue>
 		<ShortDescription>504 accommodation</ShortDescription>

--- a/Descriptors/AccountClassificationDescriptor.xml
+++ b/Descriptors/AccountClassificationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AccountClassificationDescriptor>
 		<CodeValue>Fund</CodeValue>
 		<ShortDescription>Fund</ShortDescription>

--- a/Descriptors/AchievementCategoryDescriptor.xml
+++ b/Descriptors/AchievementCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AchievementCategoryDescriptor>
 		<CodeValue>Academic Honor</CodeValue>
 		<ShortDescription>Academic Honor</ShortDescription>

--- a/Descriptors/AdditionalCreditTypeDescriptor.xml
+++ b/Descriptors/AdditionalCreditTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AdditionalCreditTypeDescriptor>
 		<CodeValue>Advanced Placement</CodeValue>
 		<ShortDescription>Advanced Placement</ShortDescription>

--- a/Descriptors/AddressTypeDescriptor.xml
+++ b/Descriptors/AddressTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AddressTypeDescriptor>
 		<CodeValue>Billing</CodeValue>
 		<ShortDescription>Billing</ShortDescription>

--- a/Descriptors/AdministrationEnvironmentDescriptor.xml
+++ b/Descriptors/AdministrationEnvironmentDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AdministrationEnvironmentDescriptor>
 		<CodeValue>Classroom</CodeValue>
 		<ShortDescription>Classroom</ShortDescription>

--- a/Descriptors/AdministrativeFundingControlDescriptor.xml
+++ b/Descriptors/AdministrativeFundingControlDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AdministrativeFundingControlDescriptor>
 		<CodeValue>Other</CodeValue>
 		<ShortDescription>Other</ShortDescription>

--- a/Descriptors/AssessmentCategoryDescriptor.xml
+++ b/Descriptors/AssessmentCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentCategoryDescriptor>
 		<CodeValue>Advanced Placement</CodeValue>
 		<ShortDescription>Advanced Placement</ShortDescription>

--- a/Descriptors/AssessmentIdentificationSystemDescriptor.xml
+++ b/Descriptors/AssessmentIdentificationSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentIdentificationSystemDescriptor>
 		<CodeValue>District</CodeValue>
 		<ShortDescription>District</ShortDescription>

--- a/Descriptors/AssessmentItemCategoryDescriptor.xml
+++ b/Descriptors/AssessmentItemCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentItemCategoryDescriptor>
 		<CodeValue>Analytic</CodeValue>
 		<ShortDescription>Analytic</ShortDescription>

--- a/Descriptors/AssessmentItemResultDescriptor.xml
+++ b/Descriptors/AssessmentItemResultDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentItemResultDescriptor>
 		<CodeValue>Above Standard</CodeValue>
 		<ShortDescription>Above Standard</ShortDescription>

--- a/Descriptors/AssessmentPeriodDescriptor.xml
+++ b/Descriptors/AssessmentPeriodDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentPeriodDescriptor>
 		<CodeValue>BOY</CodeValue>
 		<ShortDescription>BOY</ShortDescription>

--- a/Descriptors/AssessmentReportingMethodDescriptor.xml
+++ b/Descriptors/AssessmentReportingMethodDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AssessmentReportingMethodDescriptor>
 		<CodeValue>Achievement/proficiency level</CodeValue>
 		<ShortDescription>Achievement/proficiency level</ShortDescription>

--- a/Descriptors/AttemptStatusDescriptor.xml
+++ b/Descriptors/AttemptStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AttemptStatusDescriptor>
 		<CodeValue>Pass</CodeValue>
 		<ShortDescription>Pass</ShortDescription>

--- a/Descriptors/AttendanceEventCategoryDescriptor.xml
+++ b/Descriptors/AttendanceEventCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AttendanceEventCategoryDescriptor>
 		<CodeValue>In Attendance</CodeValue>
 		<ShortDescription>In Attendance</ShortDescription>

--- a/Descriptors/BehaviorDescriptor.xml
+++ b/Descriptors/BehaviorDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<BehaviorDescriptor>
 		<CodeValue>State Offense</CodeValue>
 		<ShortDescription>State Offense</ShortDescription>

--- a/Descriptors/CTEProgramServiceDescriptor.xml
+++ b/Descriptors/CTEProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CTEProgramServiceDescriptor>
 		<CodeValue>Agriculture, Food and Natural Resources</CodeValue>
 		<ShortDescription>Agriculture, Food and Natural Resources</ShortDescription>

--- a/Descriptors/CalendarEventDescriptor.xml
+++ b/Descriptors/CalendarEventDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CalendarEventDescriptor>
 		<CodeValue>Emergency day</CodeValue>
 		<ShortDescription>Emergency day</ShortDescription>

--- a/Descriptors/CalendarTypeDescriptor.xml
+++ b/Descriptors/CalendarTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CalendarTypeDescriptor>
 		<CodeValue>IEP</CodeValue>
 		<ShortDescription>IEP</ShortDescription>

--- a/Descriptors/CareerPathwayDescriptor.xml
+++ b/Descriptors/CareerPathwayDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CareerPathwayDescriptor>
 		<CodeValue>Agriculture, Food and Natural Resources</CodeValue>
 		<ShortDescription>Agriculture, Food and Natural Resources</ShortDescription>

--- a/Descriptors/CharterApprovalAgencyTypeDescriptor.xml
+++ b/Descriptors/CharterApprovalAgencyTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CharterApprovalAgencyTypeDescriptor>
 		<CodeValue>Other</CodeValue>
 		<ShortDescription>Other</ShortDescription>

--- a/Descriptors/CharterStatusDescriptor.xml
+++ b/Descriptors/CharterStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CharterStatusDescriptor>
 		<CodeValue>College/University Charter</CodeValue>
 		<ShortDescription>College/University Charter</ShortDescription>

--- a/Descriptors/CitizenshipStatusDescriptor.xml
+++ b/Descriptors/CitizenshipStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 <CitizenshipStatusDescriptor>
 	<CodeValue>Non-resident alien</CodeValue>
 	<ShortDescription>Non-resident alien</ShortDescription>

--- a/Descriptors/ClassroomPositionDescriptor.xml
+++ b/Descriptors/ClassroomPositionDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ClassroomPositionDescriptor>
 		<CodeValue>Assistant Teacher</CodeValue>
 		<ShortDescription>Assistant Teacher</ShortDescription>

--- a/Descriptors/CohortScopeDescriptor.xml
+++ b/Descriptors/CohortScopeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CohortScopeDescriptor>
 		<CodeValue>Classroom</CodeValue>
 		<ShortDescription>Classroom</ShortDescription>

--- a/Descriptors/CohortTypeDescriptor.xml
+++ b/Descriptors/CohortTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CohortTypeDescriptor>
 		<CodeValue>Academic Intervention</CodeValue>
 		<ShortDescription>Academic Intervention</ShortDescription>

--- a/Descriptors/CohortYearTypeDescriptor.xml
+++ b/Descriptors/CohortYearTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CohortYearTypeDescriptor>
 		<CodeValue>Eighth grade</CodeValue>
 		<ShortDescription>Eighth grade</ShortDescription>

--- a/Descriptors/CompetencyLevelDescriptor.xml
+++ b/Descriptors/CompetencyLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CompetencyLevelDescriptor>
 		<CodeValue>Advanced</CodeValue>
 		<ShortDescription>Advanced</ShortDescription>

--- a/Descriptors/ContactTypeDescriptor.xml
+++ b/Descriptors/ContactTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ContactTypeDescriptor>
 		<CodeValue>Other</CodeValue>
 		<ShortDescription>Other</ShortDescription>

--- a/Descriptors/ContentClassDescriptor.xml
+++ b/Descriptors/ContentClassDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ContentClassDescriptor>
 		<CodeValue>Education Research</CodeValue>
 		<ShortDescription>Education Research</ShortDescription>

--- a/Descriptors/ContinuationOfServicesReasonDescriptor.xml
+++ b/Descriptors/ContinuationOfServicesReasonDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ContinuationOfServicesReasonDescriptor>
 		<CodeValue>Ceased to be migratory during previous term</CodeValue>
 		<ShortDescription>Ceased to be migratory in previous term - comparable services not available</ShortDescription>

--- a/Descriptors/CostRateDescriptor.xml
+++ b/Descriptors/CostRateDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CostRateDescriptor>
 		<CodeValue>Flat Fee</CodeValue>
 		<ShortDescription>Flat Fee</ShortDescription>

--- a/Descriptors/CountryDescriptor.xml
+++ b/Descriptors/CountryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CountryDescriptor>
 		<CodeValue>AD</CodeValue>
 		<ShortDescription>Andorra</ShortDescription>

--- a/Descriptors/CourseAttemptResultDescriptor.xml
+++ b/Descriptors/CourseAttemptResultDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseAttemptResultDescriptor>
 		<CodeValue>Fail</CodeValue>
 		<ShortDescription>Fail</ShortDescription>

--- a/Descriptors/CourseDefinedByDescriptor.xml
+++ b/Descriptors/CourseDefinedByDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseDefinedByDescriptor>
 		<CodeValue>LEA</CodeValue>
 		<ShortDescription>LEA</ShortDescription>

--- a/Descriptors/CourseGPAApplicabilityDescriptor.xml
+++ b/Descriptors/CourseGPAApplicabilityDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseGPAApplicabilityDescriptor>
 		<CodeValue>Applicable</CodeValue>
 		<ShortDescription>Applicable</ShortDescription>

--- a/Descriptors/CourseIdentificationSystemDescriptor.xml
+++ b/Descriptors/CourseIdentificationSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseIdentificationSystemDescriptor>
 		<CodeValue>CSSC course code</CodeValue>
 		<ShortDescription>CSSC course code</ShortDescription>

--- a/Descriptors/CourseLevelCharacteristicDescriptor.xml
+++ b/Descriptors/CourseLevelCharacteristicDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseLevelCharacteristicDescriptor>
 		<CodeValue>Accepted as high school equivalent</CodeValue>
 		<ShortDescription>Accepted as high school equivalent</ShortDescription>

--- a/Descriptors/CourseRepeatCodeDescriptor.xml
+++ b/Descriptors/CourseRepeatCodeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CourseRepeatCodeDescriptor>
 		<CodeValue>Not Counted Other</CodeValue>
 		<ShortDescription>Not Counted Other</ShortDescription>

--- a/Descriptors/CredentialFieldDescriptor.xml
+++ b/Descriptors/CredentialFieldDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CredentialFieldDescriptor>
 		<CodeValue>Computer Science</CodeValue>
 		<ShortDescription>Computer Science</ShortDescription>

--- a/Descriptors/CredentialTypeDescriptor.xml
+++ b/Descriptors/CredentialTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CredentialTypeDescriptor>
 		<CodeValue>Certification</CodeValue>
 		<ShortDescription>Certification</ShortDescription>

--- a/Descriptors/CreditTypeDescriptor.xml
+++ b/Descriptors/CreditTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CreditTypeDescriptor>
 		<CodeValue>Adult education credit</CodeValue>
 		<ShortDescription>Adult education credit</ShortDescription>

--- a/Descriptors/CurriculumUsedDescriptor.xml
+++ b/Descriptors/CurriculumUsedDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CurriculumUsedDescriptor>
 		<CodeValue>Creative curriculum family child care</CodeValue>
 		<ShortDescription>Creative curriculum family child care</ShortDescription>

--- a/Descriptors/DeliveryMethodDescriptor.xml
+++ b/Descriptors/DeliveryMethodDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DeliveryMethodDescriptor>
 		<CodeValue>Individual</CodeValue>
 		<ShortDescription>Individual</ShortDescription>

--- a/Descriptors/DiagnosisDescriptor.xml
+++ b/Descriptors/DiagnosisDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DiagnosisDescriptor>
 		<CodeValue>Low Attendance</CodeValue>
 		<ShortDescription>Low Attendance</ShortDescription>

--- a/Descriptors/DiplomaLevelDescriptor.xml
+++ b/Descriptors/DiplomaLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DiplomaLevelDescriptor>
 		<CodeValue>Cum laude</CodeValue>
 		<ShortDescription>Cum laude</ShortDescription>

--- a/Descriptors/DiplomaTypeDescriptor.xml
+++ b/Descriptors/DiplomaTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DiplomaTypeDescriptor>
 		<CodeValue>Alternative credential</CodeValue>
 		<ShortDescription>Alternative credential</ShortDescription>

--- a/Descriptors/DisabilityDescriptor.xml
+++ b/Descriptors/DisabilityDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisabilityDescriptor>
 		<CodeValue>Autism Spectrum Disorders</CodeValue>
 		<ShortDescription>Autism Spectrum Disorders</ShortDescription>

--- a/Descriptors/DisabilityDesignationDescriptor.xml
+++ b/Descriptors/DisabilityDesignationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisabilityDesignationDescriptor>
 		<CodeValue>Individuals with Disabilities Education Act</CodeValue>
 		<ShortDescription>Individuals with Disabilities Education Act</ShortDescription>

--- a/Descriptors/DisabilityDeterminationSourceTypeDescriptor.xml
+++ b/Descriptors/DisabilityDeterminationSourceTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisabilityDeterminationSourceTypeDescriptor>
 		<CodeValue>By health care provider</CodeValue>
 		<ShortDescription>By health care provider</ShortDescription>

--- a/Descriptors/DisciplineActionLengthDifferenceReasonDescriptor.xml
+++ b/Descriptors/DisciplineActionLengthDifferenceReasonDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisciplineActionLengthDifferenceReasonDescriptor>
 		<CodeValue>Continuation Of Prior Year's Disciplinary Action</CodeValue>
 		<ShortDescription>Continuation Of Previous Year's Disciplinary Action Assignment</ShortDescription>

--- a/Descriptors/DisciplineDescriptor.xml
+++ b/Descriptors/DisciplineDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisciplineDescriptor>
 		<CodeValue>Removal from Classroom</CodeValue>
 		<ShortDescription>Removal from Classroom</ShortDescription>

--- a/Descriptors/DisciplineIncidentParticipationCodeDescriptor.xml
+++ b/Descriptors/DisciplineIncidentParticipationCodeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DisciplineIncidentParticipationCodeDescriptor>
 		<CodeValue>Perpetrator</CodeValue>
 		<ShortDescription>Perpetrator</ShortDescription>

--- a/Descriptors/EducationOrganizationCategoryDescriptor.xml
+++ b/Descriptors/EducationOrganizationCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducationOrganizationCategoryDescriptor>
 		<CodeValue>Education Organization Network</CodeValue>
 		<ShortDescription>Education Organization Network</ShortDescription>

--- a/Descriptors/EducationOrganizationIdentificationSystemDescriptor.xml
+++ b/Descriptors/EducationOrganizationIdentificationSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducationOrganizationIdentificationSystemDescriptor>
 		<CodeValue>ACT</CodeValue>
 		<ShortDescription>ACT</ShortDescription>

--- a/Descriptors/EducationPlanDescriptor.xml
+++ b/Descriptors/EducationPlanDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducationPlanDescriptor>
 		<CodeValue>504 Plan</CodeValue>
 		<ShortDescription>504 Plan</ShortDescription>

--- a/Descriptors/EducationalEnvironmentDescriptor.xml
+++ b/Descriptors/EducationalEnvironmentDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducationalEnvironmentDescriptor>
 		<CodeValue>Classroom</CodeValue>
 		<ShortDescription>Classroom</ShortDescription>

--- a/Descriptors/ElectronicMailTypeDescriptor.xml
+++ b/Descriptors/ElectronicMailTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ElectronicMailTypeDescriptor>
 		<CodeValue>Home/Personal</CodeValue>
 		<ShortDescription>Home/Personal</ShortDescription>

--- a/Descriptors/EmploymentStatusDescriptor.xml
+++ b/Descriptors/EmploymentStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EmploymentStatusDescriptor>
 		<CodeValue>Probationary</CodeValue>
 		<ShortDescription>Probationary</ShortDescription>

--- a/Descriptors/EntryGradeLevelReasonDescriptor.xml
+++ b/Descriptors/EntryGradeLevelReasonDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EntryGradeLevelReasonDescriptor>
 		<CodeValue>Nonpromotion - Failed to meet testing requirements</CodeValue>
 		<ShortDescription>Nonpromotion - Failed to meet testing requirements</ShortDescription>

--- a/Descriptors/EntryTypeDescriptor.xml
+++ b/Descriptors/EntryTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EntryTypeDescriptor>
 		<CodeValue>Transfer</CodeValue>
 		<ShortDescription>Transfer</ShortDescription>

--- a/Descriptors/EventCircumstanceDescriptor.xml
+++ b/Descriptors/EventCircumstanceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EventCircumstanceDescriptor>
 		<CodeValue>Administration or system failure</CodeValue>
 		<ShortDescription>Administration or system failure</ShortDescription>

--- a/Descriptors/ExitWithdrawTypeDescriptor.xml
+++ b/Descriptors/ExitWithdrawTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ExitWithdrawTypeDescriptor>
 		<CodeValue>Completed</CodeValue>
 		<ShortDescription>Completed</ShortDescription>

--- a/Descriptors/GradeLevelDescriptor.xml
+++ b/Descriptors/GradeLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GradeLevelDescriptor>
 		<CodeValue>Adult Education</CodeValue>
 		<ShortDescription>Adult Education</ShortDescription>

--- a/Descriptors/GradePointAverageTypeDescriptor.xml
+++ b/Descriptors/GradePointAverageTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GradePointAverageTypeDescriptor>
 		<CodeValue>Weighted</CodeValue>
 		<ShortDescription>Weighted</ShortDescription>

--- a/Descriptors/GradeTypeDescriptor.xml
+++ b/Descriptors/GradeTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GradeTypeDescriptor>
 		<CodeValue>Conduct</CodeValue>
 		<ShortDescription>Conduct</ShortDescription>

--- a/Descriptors/GradebookEntryTypeDescriptor.xml
+++ b/Descriptors/GradebookEntryTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GradebookEntryTypeDescriptor>
 		<CodeValue>Activity</CodeValue>
 		<ShortDescription>Activity</ShortDescription>

--- a/Descriptors/GradingPeriodDescriptor.xml
+++ b/Descriptors/GradingPeriodDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GradingPeriodDescriptor>
 		<CodeValue>End of Year</CodeValue>
 		<ShortDescription>End of Year</ShortDescription>

--- a/Descriptors/GraduationPlanTypeDescriptor.xml
+++ b/Descriptors/GraduationPlanTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GraduationPlanTypeDescriptor>
 		<CodeValue>Career and Technical Education</CodeValue>
 		<ShortDescription>Career and Technical Education</ShortDescription>

--- a/Descriptors/GunFreeSchoolsActReportingStatusDescriptor.xml
+++ b/Descriptors/GunFreeSchoolsActReportingStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<GunFreeSchoolsActReportingStatusDescriptor>
 		<CodeValue>No</CodeValue>
 		<ShortDescription>No</ShortDescription>

--- a/Descriptors/HomelessPrimaryNighttimeResidenceDescriptor.xml
+++ b/Descriptors/HomelessPrimaryNighttimeResidenceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<HomelessPrimaryNighttimeResidenceDescriptor>
 		<CodeValue>Doubled-up</CodeValue>
 		<ShortDescription>Doubled-up</ShortDescription>

--- a/Descriptors/HomelessProgramServiceDescriptor.xml
+++ b/Descriptors/HomelessProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<HomelessProgramServiceDescriptor>
 		<CodeValue>Instructional Services</CodeValue>
 		<ShortDescription>Instructional Services</ShortDescription>

--- a/Descriptors/IdentificationDocumentUseDescriptor.xml
+++ b/Descriptors/IdentificationDocumentUseDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<IdentificationDocumentUseDescriptor>
 		<CodeValue>Foreign Citizenship Identification</CodeValue>
 		<ShortDescription>Foreign Citizenship Identification</ShortDescription>

--- a/Descriptors/IncidentLocationDescriptor.xml
+++ b/Descriptors/IncidentLocationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<IncidentLocationDescriptor>
 		<CodeValue>Administrative offices area</CodeValue>
 		<ShortDescription>Administrative offices area</ShortDescription>

--- a/Descriptors/InstitutionTelephoneNumberTypeDescriptor.xml
+++ b/Descriptors/InstitutionTelephoneNumberTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InstitutionTelephoneNumberTypeDescriptor>
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>Administrative</ShortDescription>

--- a/Descriptors/InteractivityStyleDescriptor.xml
+++ b/Descriptors/InteractivityStyleDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InteractivityStyleDescriptor>
 		<CodeValue>Active</CodeValue>
 		<ShortDescription>Active</ShortDescription>

--- a/Descriptors/InternetAccessDescriptor.xml
+++ b/Descriptors/InternetAccessDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InternetAccessDescriptor>
 		<CodeValue>High Speed</CodeValue>
 		<ShortDescription>High Speed</ShortDescription>

--- a/Descriptors/InterventionClassDescriptor.xml
+++ b/Descriptors/InterventionClassDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InterventionClassDescriptor>
 		<CodeValue>Curriculum</CodeValue>
 		<ShortDescription>Curriculum</ShortDescription>

--- a/Descriptors/InterventionEffectivenessRatingDescriptor.xml
+++ b/Descriptors/InterventionEffectivenessRatingDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InterventionEffectivenessRatingDescriptor>
 		<CodeValue>Mixed Effects</CodeValue>
 		<ShortDescription>Mixed Effects</ShortDescription>

--- a/Descriptors/LanguageDescriptor.xml
+++ b/Descriptors/LanguageDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LanguageDescriptor>
 		<CodeValue>ady</CodeValue>
 		<ShortDescription>Adyghe</ShortDescription>

--- a/Descriptors/LanguageInstructionProgramServiceDescriptor.xml
+++ b/Descriptors/LanguageInstructionProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LanguageInstructionProgramServiceDescriptor>
 		<CodeValue>Dual Language</CodeValue>
 		<ShortDescription>Dual Language</ShortDescription>

--- a/Descriptors/LanguageUseDescriptor.xml
+++ b/Descriptors/LanguageUseDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LanguageUseDescriptor>
 		<CodeValue>Correspondence language</CodeValue>
 		<ShortDescription>Correspondence language</ShortDescription>

--- a/Descriptors/LearningStandardCategoryDescriptor.xml
+++ b/Descriptors/LearningStandardCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LearningStandardCategoryDescriptor>
 		<CodeValue>Practices</CodeValue>
 		<ShortDescription>Practices</ShortDescription>

--- a/Descriptors/LearningStandardEquivalenceStrengthDescriptor.xml
+++ b/Descriptors/LearningStandardEquivalenceStrengthDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LearningStandardEquivalenceStrengthDescriptor>
 		<CodeValue>Equivalent</CodeValue>
 		<ShortDescription>Equivalent</ShortDescription>

--- a/Descriptors/LearningStandardScopeDescriptor.xml
+++ b/Descriptors/LearningStandardScopeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LearningStandardScopeDescriptor>
 		<CodeValue>State</CodeValue>
 		<ShortDescription>State</ShortDescription>

--- a/Descriptors/LevelOfEducationDescriptor.xml
+++ b/Descriptors/LevelOfEducationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LevelOfEducationDescriptor>
 		<CodeValue>Associate's Degree (two years or more)</CodeValue>
 		<ShortDescription>Associate's Degree (two years or more)</ShortDescription>

--- a/Descriptors/LicenseStatusDescriptor.xml
+++ b/Descriptors/LicenseStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LicenseStatusDescriptor>
 		<CodeValue>Exempt</CodeValue>
 		<ShortDescription>Exempt</ShortDescription>

--- a/Descriptors/LicenseTypeDescriptor.xml
+++ b/Descriptors/LicenseTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LicenseTypeDescriptor>
 		<CodeValue>Before- and After-School Programs</CodeValue>
 		<ShortDescription>Before- and After-School Programs</ShortDescription>

--- a/Descriptors/LimitedEnglishProficiencyDescriptor.xml
+++ b/Descriptors/LimitedEnglishProficiencyDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LimitedEnglishProficiencyDescriptor>
 		<CodeValue>Limited</CodeValue>
 		<ShortDescription>Limited</ShortDescription>

--- a/Descriptors/LocalEducationAgencyCategoryDescriptor.xml
+++ b/Descriptors/LocalEducationAgencyCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LocalEducationAgencyCategoryDescriptor>
 		<CodeValue>Charter</CodeValue>
 		<ShortDescription>Charter</ShortDescription>

--- a/Descriptors/LocaleDescriptor.xml
+++ b/Descriptors/LocaleDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<LocaleDescriptor>
 		<CodeValue>City-Large</CodeValue>
 		<ShortDescription>City-Large</ShortDescription>

--- a/Descriptors/MagnetSpecialProgramEmphasisSchoolDescriptor.xml
+++ b/Descriptors/MagnetSpecialProgramEmphasisSchoolDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<MagnetSpecialProgramEmphasisSchoolDescriptor>
 		<CodeValue>All students participate</CodeValue>
 		<ShortDescription>All students participate</ShortDescription>

--- a/Descriptors/MediumOfInstructionDescriptor.xml
+++ b/Descriptors/MediumOfInstructionDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<MediumOfInstructionDescriptor>
 		<CodeValue>Center-based instruction</CodeValue>
 		<ShortDescription>Center-based instruction</ShortDescription>

--- a/Descriptors/MethodCreditEarnedDescriptor.xml
+++ b/Descriptors/MethodCreditEarnedDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<MethodCreditEarnedDescriptor>
 		<CodeValue>Classroom credit</CodeValue>
 		<ShortDescription>Classroom credit</ShortDescription>

--- a/Descriptors/MigrantEducationProgramServiceDescriptor.xml
+++ b/Descriptors/MigrantEducationProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<MigrantEducationProgramServiceDescriptor>
 		<CodeValue>Counseling Services</CodeValue>
 		<ShortDescription>Counseling Services</ShortDescription>

--- a/Descriptors/MonitoredDescriptor.xml
+++ b/Descriptors/MonitoredDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<MonitoredDescriptor>
 		<CodeValue>Year 1</CodeValue>
 		<ShortDescription>Year 1</ShortDescription>

--- a/Descriptors/NeglectedOrDelinquentProgramDescriptor.xml
+++ b/Descriptors/NeglectedOrDelinquentProgramDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<NeglectedOrDelinquentProgramDescriptor>
 		<CodeValue>Neglected Programs</CodeValue>
 		<ShortDescription>Neglected Programs</ShortDescription>

--- a/Descriptors/NeglectedOrDelinquentProgramServiceDescriptor.xml
+++ b/Descriptors/NeglectedOrDelinquentProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<NeglectedOrDelinquentProgramServiceDescriptor>
 		<CodeValue>Transition Programs</CodeValue>
 		<ShortDescription>Transition Programs</ShortDescription>

--- a/Descriptors/NetworkPurposeDescriptor.xml
+++ b/Descriptors/NetworkPurposeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<NetworkPurposeDescriptor>
 		<CodeValue>Collective Procurement</CodeValue>
 		<ShortDescription>Collective Procurement</ShortDescription>

--- a/Descriptors/OldEthnicityDescriptor.xml
+++ b/Descriptors/OldEthnicityDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<OldEthnicityDescriptor>
 		<CodeValue>American Indian Or Alaskan Native</CodeValue>
 		<ShortDescription>American Indian Or Alaskan Native</ShortDescription>

--- a/Descriptors/OperationalStatusDescriptor.xml
+++ b/Descriptors/OperationalStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<OperationalStatusDescriptor>
 		<CodeValue>Active</CodeValue>
 		<ShortDescription>Active</ShortDescription>

--- a/Descriptors/OtherNameTypeDescriptor.xml
+++ b/Descriptors/OtherNameTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<OtherNameTypeDescriptor>
 		<CodeValue>Alias</CodeValue>
 		<ShortDescription>Alias</ShortDescription>

--- a/Descriptors/ParticipationDescriptor.xml
+++ b/Descriptors/ParticipationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ParticipationDescriptor>
 		<CodeValue>Completed</CodeValue>
 		<ShortDescription>Completed</ShortDescription>

--- a/Descriptors/ParticipationStatusDescriptor.xml
+++ b/Descriptors/ParticipationStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ParticipationStatusDescriptor>
 		<CodeValue>Referred</CodeValue>
 		<ShortDescription>Referred</ShortDescription>

--- a/Descriptors/PerformanceBaseConversionDescriptor.xml
+++ b/Descriptors/PerformanceBaseConversionDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PerformanceBaseConversionDescriptor>
 		<CodeValue>Advanced</CodeValue>
 		<ShortDescription>Advanced</ShortDescription>

--- a/Descriptors/PerformanceLevelDescriptor.xml
+++ b/Descriptors/PerformanceLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PerformanceLevelDescriptor>
 		<CodeValue>Advanced</CodeValue>
 		<ShortDescription>Advanced</ShortDescription>

--- a/Descriptors/PersonalInformationVerificationDescriptor.xml
+++ b/Descriptors/PersonalInformationVerificationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PersonalInformationVerificationDescriptor>
 		<CodeValue>Baptismal or church certificate</CodeValue>
 		<ShortDescription>Baptismal or church certificate</ShortDescription>

--- a/Descriptors/PlatformTypeDescriptor.xml
+++ b/Descriptors/PlatformTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PlatformTypeDescriptor>
 		<CodeValue>Computer-based</CodeValue>
 		<ShortDescription>Computer-based</ShortDescription>

--- a/Descriptors/PopulationServedDescriptor.xml
+++ b/Descriptors/PopulationServedDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PopulationServedDescriptor>
 		<CodeValue>Adult Basic Education Students</CodeValue>
 		<ShortDescription>Adult Basic Education Students</ShortDescription>

--- a/Descriptors/PostSecondaryEventCategoryDescriptor.xml
+++ b/Descriptors/PostSecondaryEventCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PostSecondaryEventCategoryDescriptor>
 		<CodeValue>Certification Received</CodeValue>
 		<ShortDescription>Certification Received</ShortDescription>

--- a/Descriptors/PostSecondaryInstitutionLevelDescriptor.xml
+++ b/Descriptors/PostSecondaryInstitutionLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PostSecondaryInstitutionLevelDescriptor>
 		<CodeValue>At least 2 but less than 4 years</CodeValue>
 		<ShortDescription>At least 2 but less than 4 years</ShortDescription>

--- a/Descriptors/PostingResultDescriptor.xml
+++ b/Descriptors/PostingResultDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PostingResultDescriptor>
 		<CodeValue>Position Filled</CodeValue>
 		<ShortDescription>Position Filled</ShortDescription>

--- a/Descriptors/ProficiencyDescriptor.xml
+++ b/Descriptors/ProficiencyDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProficiencyDescriptor>
 		<CodeValue>Proficient</CodeValue>
 		<ShortDescription>Proficient</ShortDescription>

--- a/Descriptors/ProgramAssignmentDescriptor.xml
+++ b/Descriptors/ProgramAssignmentDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgramAssignmentDescriptor>
 		<CodeValue>Bilingual/English as a Second Language</CodeValue>
 		<ShortDescription>Bilingual/English as a Second Language</ShortDescription>

--- a/Descriptors/ProgramSponsorDescriptor.xml
+++ b/Descriptors/ProgramSponsorDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgramSponsorDescriptor>
 		<CodeValue>Business</CodeValue>
 		<ShortDescription>Business</ShortDescription>

--- a/Descriptors/ProgramTypeDescriptor.xml
+++ b/Descriptors/ProgramTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgramTypeDescriptor>
 		<CodeValue>Adult/Continuing Education</CodeValue>
 		<ShortDescription>Adult/Continuing Education</ShortDescription>

--- a/Descriptors/ProgressDescriptor.xml
+++ b/Descriptors/ProgressDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgressDescriptor>
 		<CodeValue>Progress</CodeValue>
 		<ShortDescription>Progress</ShortDescription>

--- a/Descriptors/ProgressLevelDescriptor.xml
+++ b/Descriptors/ProgressLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgressLevelDescriptor>
 		<CodeValue>Negative Grade</CodeValue>
 		<ShortDescription>Negative Grade</ShortDescription>

--- a/Descriptors/ProviderCategoryDescriptor.xml
+++ b/Descriptors/ProviderCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProviderCategoryDescriptor>
 		<CodeValue>Center-EC with SA</CodeValue>
 		<ShortDescription>Center-EC with SA</ShortDescription>

--- a/Descriptors/ProviderProfitabilityDescriptor.xml
+++ b/Descriptors/ProviderProfitabilityDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProviderProfitabilityDescriptor>
 		<CodeValue>Government Run</CodeValue>
 		<ShortDescription>Government Run</ShortDescription>

--- a/Descriptors/ProviderStatusDescriptor.xml
+++ b/Descriptors/ProviderStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProviderStatusDescriptor>
 		<CodeValue>Active</CodeValue>
 		<ShortDescription>Active</ShortDescription>

--- a/Descriptors/PublicationStatusDescriptor.xml
+++ b/Descriptors/PublicationStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PublicationStatusDescriptor>
 		<CodeValue>Adopted</CodeValue>
 		<ShortDescription>Adopted</ShortDescription>

--- a/Descriptors/QuestionFormDescriptor.xml
+++ b/Descriptors/QuestionFormDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
     <QuestionFormDescriptor>
 		<CodeValue>Radio box</CodeValue>
 		<ShortDescription>Radio box</ShortDescription>

--- a/Descriptors/RaceDescriptor.xml
+++ b/Descriptors/RaceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RaceDescriptor>
 		<CodeValue>American Indian - Alaska Native</CodeValue>
 		<ShortDescription>American Indian - Alaska Native</ShortDescription>

--- a/Descriptors/ReasonExitedDescriptor.xml
+++ b/Descriptors/ReasonExitedDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ReasonExitedDescriptor>
 		<CodeValue>Died or is permanently incapacitated</CodeValue>
 		<ShortDescription>Died or is permanently incapacitated</ShortDescription>

--- a/Descriptors/ReasonNotTestedDescriptor.xml
+++ b/Descriptors/ReasonNotTestedDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ReasonNotTestedDescriptor>
 		<CodeValue>Absent</CodeValue>
 		<ShortDescription>Absent</ShortDescription>

--- a/Descriptors/RecognitionTypeDescriptor.xml
+++ b/Descriptors/RecognitionTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RecognitionTypeDescriptor>
 		<CodeValue>Athletic awards</CodeValue>
 		<ShortDescription>Athletic awards</ShortDescription>

--- a/Descriptors/RelationDescriptor.xml
+++ b/Descriptors/RelationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RelationDescriptor>
 		<CodeValue>Aunt</CodeValue>
 		<ShortDescription>Aunt</ShortDescription>

--- a/Descriptors/RepeatIdentifierDescriptor.xml
+++ b/Descriptors/RepeatIdentifierDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RepeatIdentifierDescriptor>
 		<CodeValue>Not repeated</CodeValue>
 		<ShortDescription>Not repeated</ShortDescription>

--- a/Descriptors/ReporterDescriptionDescriptor.xml
+++ b/Descriptors/ReporterDescriptionDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ReporterDescriptionDescriptor>
 		<CodeValue>Law enforcement officer</CodeValue>
 		<ShortDescription>Law enforcement officer</ShortDescription>

--- a/Descriptors/ResidencyStatusDescriptor.xml
+++ b/Descriptors/ResidencyStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ResidencyStatusDescriptor>
 		<CodeValue>Resident of admin unit and school area</CodeValue>
 		<ShortDescription>Resident of administrative unit and usual school attendance area</ShortDescription>

--- a/Descriptors/ResponseIndicatorDescriptor.xml
+++ b/Descriptors/ResponseIndicatorDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ResponseIndicatorDescriptor>
 		<CodeValue>Effective response</CodeValue>
 		<ShortDescription>Effective response</ShortDescription>

--- a/Descriptors/ResponsibilityDescriptor.xml
+++ b/Descriptors/ResponsibilityDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ResponsibilityDescriptor>
 		<CodeValue>Accountability</CodeValue>
 		<ShortDescription>Accountability</ShortDescription>

--- a/Descriptors/RestraintEventReasonDescriptor.xml
+++ b/Descriptors/RestraintEventReasonDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RestraintEventReasonDescriptor>
 		<CodeValue>Imminent Serious Physical Harm To Others</CodeValue>
 		<ShortDescription>Imminent Serious Physical Harm To Others</ShortDescription>

--- a/Descriptors/ResultDatatypeTypeDescriptor.xml
+++ b/Descriptors/ResultDatatypeTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ResultDatatypeTypeDescriptor>
 		<CodeValue>Decimal</CodeValue>
 		<ShortDescription>Decimal</ShortDescription>

--- a/Descriptors/RetestIndicatorDescriptor.xml
+++ b/Descriptors/RetestIndicatorDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<RetestIndicatorDescriptor>
 		<CodeValue>1st Retest</CodeValue>
 		<ShortDescription>1st Retest</ShortDescription>

--- a/Descriptors/SchoolCategoryDescriptor.xml
+++ b/Descriptors/SchoolCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SchoolCategoryDescriptor>
 		<CodeValue>Adult School</CodeValue>
 		<ShortDescription>Adult School</ShortDescription>

--- a/Descriptors/SchoolChoiceImplementStatusDescriptor.xml
+++ b/Descriptors/SchoolChoiceImplementStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SchoolChoiceImplementStatusDescriptor>
 		<CodeValue>Implemented at all grade levels</CodeValue>
 		<ShortDescription>Implemented at all grade levels</ShortDescription>

--- a/Descriptors/SchoolFoodServiceProgramServiceDescriptor.xml
+++ b/Descriptors/SchoolFoodServiceProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SchoolFoodServiceProgramServiceDescriptor>
 		<CodeValue>Free Breakfast</CodeValue>
 		<ShortDescription>Free Breakfast</ShortDescription>

--- a/Descriptors/SchoolTypeDescriptor.xml
+++ b/Descriptors/SchoolTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SchoolTypeDescriptor>
 		<CodeValue>Alternative</CodeValue>
 		<ShortDescription>Alternative</ShortDescription>

--- a/Descriptors/SectionCharacteristicDescriptor.xml
+++ b/Descriptors/SectionCharacteristicDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SectionCharacteristicDescriptor>
 		<CodeValue>Attendance Tracked</CodeValue>
 		<ShortDescription>Attendance Tracked</ShortDescription>

--- a/Descriptors/SeparationDescriptor.xml
+++ b/Descriptors/SeparationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SeparationDescriptor>
 		<CodeValue>Involuntary separation</CodeValue>
 		<ShortDescription>Involuntary separation</ShortDescription>

--- a/Descriptors/SeparationReasonDescriptor.xml
+++ b/Descriptors/SeparationReasonDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SeparationReasonDescriptor>
 		<CodeValue>Change of assignment</CodeValue>
 		<ShortDescription>Change of assignment</ShortDescription>

--- a/Descriptors/ServiceDescriptor.xml
+++ b/Descriptors/ServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ServiceDescriptor>
 		<CodeValue>Assistive technology device or service</CodeValue>
 		<ShortDescription>Assistive technology device or service</ShortDescription>

--- a/Descriptors/SexDescriptor.xml
+++ b/Descriptors/SexDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SexDescriptor>
 		<CodeValue>Female</CodeValue>
 		<ShortDescription>Female</ShortDescription>

--- a/Descriptors/SourceSystemDescriptor.xml
+++ b/Descriptors/SourceSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 		<SourceSystemDescriptor>
 		<CodeValue>School</CodeValue>
 		<ShortDescription>School</ShortDescription>

--- a/Descriptors/SpecialEducationProgramServiceDescriptor.xml
+++ b/Descriptors/SpecialEducationProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SpecialEducationProgramServiceDescriptor>
 		<CodeValue>Speech-Language And Audiology Services</CodeValue>
 		<ShortDescription>Speech-Language And Audiology Services</ShortDescription>

--- a/Descriptors/SpecialEducationSettingDescriptor.xml
+++ b/Descriptors/SpecialEducationSettingDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SpecialEducationSettingDescriptor>
 		<CodeValue>Correctional Facilities</CodeValue>
 		<ShortDescription>Correctional Facilities</ShortDescription>

--- a/Descriptors/StaffClassificationDescriptor.xml
+++ b/Descriptors/StaffClassificationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StaffClassificationDescriptor>
 		<CodeValue>Pre-Kindergarten Teachers</CodeValue>
 		<ShortDescription>Pre-Kindergarten Teachers</ShortDescription>

--- a/Descriptors/StaffIdentificationSystemDescriptor.xml
+++ b/Descriptors/StaffIdentificationSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StaffIdentificationSystemDescriptor>
 		<CodeValue>Canadian SIN</CodeValue>
 		<ShortDescription>Canadian SIN</ShortDescription>

--- a/Descriptors/StaffLeaveEventCategoryDescriptor.xml
+++ b/Descriptors/StaffLeaveEventCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StaffLeaveEventCategoryDescriptor>
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>Administrative</ShortDescription>

--- a/Descriptors/StateAbbreviationDescriptor.xml
+++ b/Descriptors/StateAbbreviationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StateAbbreviationDescriptor>
 		<CodeValue>AA</CodeValue>
 		<ShortDescription>AA</ShortDescription>

--- a/Descriptors/StudentCharacteristicDescriptor.xml
+++ b/Descriptors/StudentCharacteristicDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StudentCharacteristicDescriptor>
 		<CodeValue>Asylee</CodeValue>
 		<ShortDescription>Asylee</ShortDescription>

--- a/Descriptors/StudentIdentificationSystemDescriptor.xml
+++ b/Descriptors/StudentIdentificationSystemDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StudentIdentificationSystemDescriptor>
 		<CodeValue>Canadian SIN</CodeValue>
 		<ShortDescription>Canadian SIN</ShortDescription>

--- a/Descriptors/StudentParticipationCodeDescriptor.xml
+++ b/Descriptors/StudentParticipationCodeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StudentParticipationCodeDescriptor>
 		<CodeValue>Perpetrator</CodeValue>
 		<ShortDescription>Perpetrator</ShortDescription>

--- a/Descriptors/SurveyCategoryDescriptor.xml
+++ b/Descriptors/SurveyCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<SurveyCategoryDescriptor>
 		<CodeValue>Administrator</CodeValue>
 		<ShortDescription>Administrator</ShortDescription>

--- a/Descriptors/SurveyLevelDescriptor.xml
+++ b/Descriptors/SurveyLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
     <SurveyLevelDescriptor>
 		<CodeValue>Adult Education</CodeValue>
 		<ShortDescription>Adult Education</ShortDescription>

--- a/Descriptors/TeachingCredentialBasisDescriptor.xml
+++ b/Descriptors/TeachingCredentialBasisDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TeachingCredentialBasisDescriptor>
 		<CodeValue>4-year bachelor's degree</CodeValue>
 		<ShortDescription>4-year bachelor's degree</ShortDescription>

--- a/Descriptors/TeachingCredentialDescriptor.xml
+++ b/Descriptors/TeachingCredentialDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TeachingCredentialDescriptor>
 		<CodeValue>Emergency</CodeValue>
 		<ShortDescription>Emergency</ShortDescription>

--- a/Descriptors/TechnicalSkillsAssessmentDescriptor.xml
+++ b/Descriptors/TechnicalSkillsAssessmentDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TechnicalSkillsAssessmentDescriptor>
 		<CodeValue>Passed</CodeValue>
 		<ShortDescription>Passed</ShortDescription>

--- a/Descriptors/TelephoneNumberTypeDescriptor.xml
+++ b/Descriptors/TelephoneNumberTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TelephoneNumberTypeDescriptor>
 		<CodeValue>Emergency 1</CodeValue>
 		<ShortDescription>Emergency 1</ShortDescription>

--- a/Descriptors/TermDescriptor.xml
+++ b/Descriptors/TermDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TermDescriptor>
 		<CodeValue>Semester</CodeValue>
 		<ShortDescription>Semester</ShortDescription>

--- a/Descriptors/TitleIPartAParticipantDescriptor.xml
+++ b/Descriptors/TitleIPartAParticipantDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TitleIPartAParticipantDescriptor>
 		<CodeValue>Local Neglected Program</CodeValue>
 		<ShortDescription>DEPRECATED: Local Neglected Program</ShortDescription>

--- a/Descriptors/TitleIPartAProgramServiceDescriptor.xml
+++ b/Descriptors/TitleIPartAProgramServiceDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TitleIPartAProgramServiceDescriptor>
 		<CodeValue>Reading/Language Instructional Services</CodeValue>
 		<ShortDescription>Reading/Language Instructional Services</ShortDescription>

--- a/Descriptors/TitleIPartASchoolDesignationDescriptor.xml
+++ b/Descriptors/TitleIPartASchoolDesignationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TitleIPartASchoolDesignationDescriptor>
 		<CodeValue>Not A Title I School</CodeValue>
 		<ShortDescription>Not A Title I School</ShortDescription>

--- a/Descriptors/TribalAffiliationDescriptor.xml
+++ b/Descriptors/TribalAffiliationDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<TribalAffiliationDescriptor>
 		<CodeValue>Absentee-Shawnee</CodeValue>
 		<ShortDescription>Absentee-Shawnee</ShortDescription>

--- a/Descriptors/VisaDescriptor.xml
+++ b/Descriptors/VisaDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<VisaDescriptor>
 		<CodeValue>B1 - Business Visa</CodeValue>
 		<ShortDescription>B1 - Business Visa</ShortDescription>

--- a/Descriptors/WeaponDescriptor.xml
+++ b/Descriptors/WeaponDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<WeaponDescriptor>
 		<CodeValue>Club</CodeValue>
 		<ShortDescription>Club</ShortDescription>

--- a/Samples/Sample XML/AncestryEthnicOriginDescriptor.xml
+++ b/Samples/Sample XML/AncestryEthnicOriginDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AncestryEthnicOriginDescriptor>
 		<CodeValue>Colombian</CodeValue>
 		<ShortDescription>Colombian</ShortDescription>

--- a/Samples/Sample XML/AssessmentMetadata-ACT.xml
+++ b/Samples/Sample XML/AssessmentMetadata-ACT.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>ACT Composite</AssessmentIdentifier>
 		<AssessmentTitle>ACT</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeMath.xml
+++ b/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeMath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>ae049cb3-33d0-431f-b0f3-a751df7217ef</AssessmentIdentifier>
 		<AssessmentTitle>3rd Grade Math 1st Six Weeks 2012-2013</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeMathModified.xml
+++ b/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeMathModified.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>39576404-04d2-4c06-a0e7-e2cb27968d01</AssessmentIdentifier>
 		<AssessmentTitle>3rd Grade Modified Math 1st Six Weeks 2012-2013</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReading.xml
+++ b/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReading.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>01774fa3-06f1-47fe-8801-c8b1e65057f2</AssessmentIdentifier>
 		<AssessmentTitle>3rd Grade Reading 1st Six Weeks 2012-2013</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReadingModified.xml
+++ b/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReadingModified.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>3e0e2cac-847b-4ddd-93ec-925826552447</AssessmentIdentifier>
 		<AssessmentTitle>3rd Grade Modified Reading 2nd Six Weeks 2012-2013</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReadingSpanish.xml
+++ b/Samples/Sample XML/AssessmentMetadata-Benchmarks-3rdGradeReadingSpanish.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>1a6a5d20-4758-4f45-848d-59f3f03ae425</AssessmentIdentifier>
 		<AssessmentTitle>3rd Grade Reading 2nd Six Weeks 2012-2013 Spanish</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-LearningStandardsMastery.xml
+++ b/Samples/Sample XML/AssessmentMetadata-LearningStandardsMastery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>MP-2013-Mathematics-Seventh grade</AssessmentIdentifier>
 		<AssessmentTitle>7th Grade Math Placement</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-SAT.xml
+++ b/Samples/Sample XML/AssessmentMetadata-SAT.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>SAT Critical Reading</AssessmentIdentifier>
 		<AssessmentTitle>SAT</AssessmentTitle>

--- a/Samples/Sample XML/AssessmentMetadata-StateAssessment.xml
+++ b/Samples/Sample XML/AssessmentMetadata-StateAssessment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
+<InterchangeAssessmentMetadata xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-AssessmentMetadata.xsd">
 	<Assessment>
 		<AssessmentIdentifier>SA-2011-Mathematics-Eighth grade</AssessmentIdentifier>
 		<AssessmentTitle>State Assessment</AssessmentTitle>

--- a/Samples/Sample XML/CreditCategoryDescriptor.xml
+++ b/Samples/Sample XML/CreditCategoryDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CreditCategoryDescriptor>
 		<CodeValue>Advanced Placement</CodeValue>
 		<ShortDescription>Advanced Placement</ShortDescription>

--- a/Samples/Sample XML/EducationOrgCalendar.xml
+++ b/Samples/Sample XML/EducationOrgCalendar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeEducationOrgCalendar xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-EducationOrgCalendar.xsd">
+<InterchangeEducationOrgCalendar xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-EducationOrgCalendar.xsd">
 	<Session>
 		<SessionName>2010-2011 Fall Semester</SessionName>
 		<SchoolYear>2010-2011</SchoolYear>

--- a/Samples/Sample XML/EducationOrganization.xml
+++ b/Samples/Sample XML/EducationOrganization.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeEducationOrganization xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-EducationOrganization.xsd">
+<InterchangeEducationOrganization xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-EducationOrganization.xsd">
 	<EducationServiceCenter id="ESC_255950">
 		<EducationOrganizationIdentificationCode>
 			<IdentificationCode>255950</IdentificationCode>

--- a/Samples/Sample XML/Finance.xml
+++ b/Samples/Sample XML/Finance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeFinance xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Finance.xsd">
+<InterchangeFinance xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Finance.xsd">
 	<Account>
 		<AccountIdentifier>1.100.100.1000</AccountIdentifier>
 		<AccountCodeReference>

--- a/Samples/Sample XML/IndicatorDescriptor.xml
+++ b/Samples/Sample XML/IndicatorDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<IndicatorDescriptor>
 		<CodeValue>Retention Rate</CodeValue>
 		<ShortDescription>Percent of staff retained</ShortDescription>

--- a/Samples/Sample XML/IndicatorGroupDescriptor.xml
+++ b/Samples/Sample XML/IndicatorGroupDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<IndicatorGroupDescriptor>
 		<CodeValue>Staff Indicator</CodeValue>
 		<ShortDescription>Staff Indicator</ShortDescription>

--- a/Samples/Sample XML/IndicatorLevelDescriptor.xml
+++ b/Samples/Sample XML/IndicatorLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<IndicatorLevelDescriptor>
 		<CodeValue>High Retention</CodeValue>
 		<ShortDescription>High Retention</ShortDescription>

--- a/Samples/Sample XML/MasterSchedule.xml
+++ b/Samples/Sample XML/MasterSchedule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeMasterSchedule xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-MasterSchedule.xsd">
+<InterchangeMasterSchedule xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-MasterSchedule.xsd">
 	<CourseOffering>
 		<LocalCourseCode>ALG-1</LocalCourseCode>
 		<SchoolReference>

--- a/Samples/Sample XML/Parent.xml
+++ b/Samples/Sample XML/Parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeParent xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Parent.xsd">
+<InterchangeParent xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Parent.xsd">
 	<Parent id="PRNT_778393">
 		<ParentUniqueId>778393</ParentUniqueId>
 		<Name>

--- a/Samples/Sample XML/PostSecondaryEvent.xml
+++ b/Samples/Sample XML/PostSecondaryEvent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangePostSecondaryEvent xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-PostSecondaryEvent.xsd">
+<InterchangePostSecondaryEvent xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-PostSecondaryEvent.xsd">
 	<PostSecondaryEvent>
 		<EventDate>2011-02-03</EventDate>
 		<PostSecondaryEventCategory>uri://ed-fi.org/PostSecondaryEventCategoryDescriptor#College Acceptance</PostSecondaryEventCategory>

--- a/Samples/Sample XML/ProgramCharacteristicDescriptor.xml
+++ b/Samples/Sample XML/ProgramCharacteristicDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ProgramCharacteristicDescriptor>
 		<CodeValue>After School</CodeValue>
 		<ShortDescription>After School</ShortDescription>

--- a/Samples/Sample XML/StaffAssociation.xml
+++ b/Samples/Sample XML/StaffAssociation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStaffAssociation xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StaffAssociation.xsd">
+<InterchangeStaffAssociation xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StaffAssociation.xsd">
 	<Staff>
 		<StaffUniqueId>207288</StaffUniqueId>
 		<StaffIdentificationCode>

--- a/Samples/Sample XML/Student.xml
+++ b/Samples/Sample XML/Student.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudent xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Student.xsd">
+<InterchangeStudent xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Student.xsd">
 	<Student>
 		<StudentUniqueId>604821</StudentUniqueId>
 		<Name>

--- a/Samples/Sample XML/StudentAssessment-ACT.xml
+++ b/Samples/Sample XML/StudentAssessment-ACT.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>/3yOGsJIN9QQhavO5qGlXgHV1ZLCQDLFr87Vvscj</StudentAssessmentIdentifier>
 		<AdministrationDate>2010-12-01T16:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeMath.xml
+++ b/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeMath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>/OYwqot8L1KQOuf5mVud8r7GALJNLxkZKOjsRN71</StudentAssessmentIdentifier>
 		<AdministrationDate>2012-09-28T15:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeMathModified.xml
+++ b/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeMathModified.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>0N/FPW+KSXQTia4gplz5D2XMILes9gr0XCxASAvX</StudentAssessmentIdentifier>
 		<AdministrationDate>2012-09-28T15:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReading.xml
+++ b/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReading.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>/Qhqqe/gI4p3RguP68ZEDArGHM64FKnCg/RLHG8c</StudentAssessmentIdentifier>
 		<AdministrationDate>2012-09-28T15:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReadingModified.xml
+++ b/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReadingModified.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>/DeXqxxLxOd4mzhavU8Fhm4VOqRnDgXRNc2SoZrN</StudentAssessmentIdentifier>
 		<AdministrationDate>2012-10-29T15:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReadingSpanish.xml
+++ b/Samples/Sample XML/StudentAssessment-Benchmarks-3rdGradeReadingSpanish.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>/2ll42pKmlaEUkmmp1XuHp7rSeR1AUEBTWBrwjHS</StudentAssessmentIdentifier>
 		<AdministrationDate>2012-10-29T15:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-LearningStandardsMastery.xml
+++ b/Samples/Sample XML/StudentAssessment-LearningStandardsMastery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>0+KxanZG+CdQReWPdaJiMPEjaCZJQP2IDP0mU2I4</StudentAssessmentIdentifier>
 		<AdministrationDate>2010-04-08T21:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-SAT.xml
+++ b/Samples/Sample XML/StudentAssessment-SAT.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>0CR2jJB43489mQDoOsxHJh7qGfZ8x4OUuyIm+/IK</StudentAssessmentIdentifier>
 		<AdministrationDate>2011-05-01T16:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentAssessment-StateAssessment.xml
+++ b/Samples/Sample XML/StudentAssessment-StateAssessment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
+<InterchangeStudentAssessment xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAssessment.xsd">
 	<StudentAssessment>
 		<StudentAssessmentIdentifier>EGpd3cZBHPxREn439BE8EhXEwEF515twfzRBpGCm</StudentAssessmentIdentifier>
 		<AdministrationDate>2010-04-01T16:00:00</AdministrationDate>

--- a/Samples/Sample XML/StudentDiscipline.xml
+++ b/Samples/Sample XML/StudentDiscipline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentDiscipline xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentDiscipline.xsd">
+<InterchangeStudentDiscipline xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentDiscipline.xsd">
 	<DisciplineIncident id="DISC_10_255901001">
 		<IncidentIdentifier>10</IncidentIdentifier>
 		<IncidentDate>2011-10-18</IncidentDate>

--- a/Samples/Sample XML/StudentGradebook.xml
+++ b/Samples/Sample XML/StudentGradebook.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentGradebook xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentGradebook.xsd">
+<InterchangeStudentGradebook xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentGradebook.xsd">
 	<GradebookEntry>
 		<GradebookEntryTitle>Assignment 1</GradebookEntryTitle>
 		<DateAssigned>2010-08-23</DateAssigned>

--- a/Samples/Sample XML/StudentIntervention.xml
+++ b/Samples/Sample XML/StudentIntervention.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentIntervention xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentIntervention.xsd">
+<InterchangeStudentIntervention xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentIntervention.xsd">
 	<EducationContent>
 		<ContentIdentifier>CheckAndConnect</ContentIdentifier>
 		<LearningResource>

--- a/Samples/Sample XML/StudentProgram.xml
+++ b/Samples/Sample XML/StudentProgram.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentProgram xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentProgram.xsd">
+<InterchangeStudentProgram xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentProgram.xsd">
 	<StudentProgramAssociation>
 		<StudentReference>
 			<StudentIdentity>

--- a/Samples/Sample XML/StudentSchoolAttendance.xml
+++ b/Samples/Sample XML/StudentSchoolAttendance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAttendance xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAttendance.xsd">
+<InterchangeStudentAttendance xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAttendance.xsd">
 	<StudentSchoolAttendanceEvent>
 		<AttendanceEvent>
 			<EventDate>2010-08-31</EventDate>

--- a/Samples/Sample XML/StudentSectionAttendance-Tardy.xml
+++ b/Samples/Sample XML/StudentSectionAttendance-Tardy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeStudentAttendance xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-StudentAttendance.xsd">
+<InterchangeStudentAttendance xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-StudentAttendance.xsd">
 	<StudentSectionAttendanceEvent>
 		<AttendanceEvent>
 			<EventDate>2011-03-07</EventDate>

--- a/Samples/Sample XML/Survey.xml
+++ b/Samples/Sample XML/Survey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeSurvey xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.0-a ../../Schemas/Bulk/Interchange-Survey.xsd">
+<InterchangeSurvey xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/3.3.1-a ../../Schemas/Bulk/Interchange-Survey.xsd">
 	<Survey>
 		<SurveyIdentifier>CE_1</SurveyIdentifier>
 		<Namespace>uri://gbisd.edu</Namespace>

--- a/Schemas/Bulk/Ed-Fi-Core.xsd
+++ b/Schemas/Bulk/Ed-Fi-Core.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" xmlns:ann="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" xmlns:ann="http://ed-fi.org/annotation" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:import namespace="http://ed-fi.org/annotation" schemaLocation="SchemaAnnotation.xsd" />
   <xs:annotation>
-		<xs:documentation>===== Ed-Fi-Core Version 3.3.0-a ====</xs:documentation>
+		<xs:documentation>===== Ed-Fi-Core Version 3.3.1-a ====</xs:documentation>
   </xs:annotation>
   <xs:annotation>
     <xs:documentation>===== Domain Entities =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-AssessmentMetadata.xsd
+++ b/Schemas/Bulk/Interchange-AssessmentMetadata.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Assessment Metadata Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Descriptors.xsd
+++ b/Schemas/Bulk/Interchange-Descriptors.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Descriptors Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-EducationOrgCalendar.xsd
+++ b/Schemas/Bulk/Interchange-EducationOrgCalendar.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Education Org Calendar Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-EducationOrganization.xsd
+++ b/Schemas/Bulk/Interchange-EducationOrganization.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Education Organization Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Finance.xsd
+++ b/Schemas/Bulk/Interchange-Finance.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Finance Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-MasterSchedule.xsd
+++ b/Schemas/Bulk/Interchange-MasterSchedule.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Master Schedule Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Parent.xsd
+++ b/Schemas/Bulk/Interchange-Parent.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="Ed-Fi-Core.xsd"/>
 	<xs:annotation>
 		<xs:documentation>===== Parent Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-PostSecondaryEvent.xsd
+++ b/Schemas/Bulk/Interchange-PostSecondaryEvent.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Post Secondary Event Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StaffAssociation.xsd
+++ b/Schemas/Bulk/Interchange-StaffAssociation.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="Ed-Fi-Core.xsd"/>
 	<xs:annotation>
 		<xs:documentation>===== Staff Association Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Standards.xsd
+++ b/Schemas/Bulk/Interchange-Standards.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Standards Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Student.xsd
+++ b/Schemas/Bulk/Interchange-Student.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="Ed-Fi-Core.xsd"/>
 	<xs:annotation>
 		<xs:documentation>===== Student Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentAssessment.xsd
+++ b/Schemas/Bulk/Interchange-StudentAssessment.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Assessment Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentAttendance.xsd
+++ b/Schemas/Bulk/Interchange-StudentAttendance.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Attendance Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentCohort.xsd
+++ b/Schemas/Bulk/Interchange-StudentCohort.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Cohort Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentDiscipline.xsd
+++ b/Schemas/Bulk/Interchange-StudentDiscipline.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Discipline Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentEnrollment.xsd
+++ b/Schemas/Bulk/Interchange-StudentEnrollment.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Enrollment Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentGrade.xsd
+++ b/Schemas/Bulk/Interchange-StudentGrade.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Grade Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentGradebook.xsd
+++ b/Schemas/Bulk/Interchange-StudentGradebook.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Gradebook Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentIntervention.xsd
+++ b/Schemas/Bulk/Interchange-StudentIntervention.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Intervention Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentProgram.xsd
+++ b/Schemas/Bulk/Interchange-StudentProgram.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Program Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-StudentTranscript.xsd
+++ b/Schemas/Bulk/Interchange-StudentTranscript.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Student Transcript Interchange Model =====</xs:documentation>

--- a/Schemas/Bulk/Interchange-Survey.xsd
+++ b/Schemas/Bulk/Interchange-Survey.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.0-a" targetNamespace="http://ed-fi.org/3.3.0-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://ed-fi.org/3.3.1-a" targetNamespace="http://ed-fi.org/3.3.1-a" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="Ed-Fi-Core.xsd" />
   <xs:annotation>
     <xs:documentation>===== Survey Interchange Model =====</xs:documentation>


### PR DESCRIPTION
- update v3.3.0-a sample data to include digital equity data
- bump xml and xsd header versions to v3.3.1-a for patch release