### PR TITLE
[DATASTD-2381] Add TPDM Descriptors - Update to 6.0.0

### DIFF
--- a/Descriptors/AccreditationStatusDescriptor.xml
+++ b/Descriptors/AccreditationStatusDescriptor.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<AccreditationStatusDescriptor>
+		<CodeValue>Accredited</CodeValue>
+		<ShortDescription>Accredited</ShortDescription>
+		<Description>Accredited</Description>
+		<Namespace>uri://ed-fi.org/AccreditationStatusDescriptor</Namespace>
+	</AccreditationStatusDescriptor>
+	<AccreditationStatusDescriptor>
+		<CodeValue>Accredited - Warned</CodeValue>
+		<ShortDescription>Accredited - Warned</ShortDescription>
+		<Description>Accredited - Warned</Description>
+		<Namespace>uri://ed-fi.org/AccreditationStatusDescriptor</Namespace>
+	</AccreditationStatusDescriptor>
+	<AccreditationStatusDescriptor>
+		<CodeValue>Accredited - Probation</CodeValue>
+		<ShortDescription>Accredited - Probation</ShortDescription>
+		<Description>Accredited - Probation</Description>
+		<Namespace>uri://ed-fi.org/AccreditationStatusDescriptor</Namespace>
+	</AccreditationStatusDescriptor>
+	<AccreditationStatusDescriptor>
+		<CodeValue>Not Accredited</CodeValue>
+		<ShortDescription>Not Accredited</ShortDescription>
+		<Description>Not Accredited</Description>
+		<Namespace>uri://ed-fi.org/AccreditationStatusDescriptor</Namespace>
+	</AccreditationStatusDescriptor>
+<AccreditationStatusDescriptor>
+		<CodeValue>Not Rated</CodeValue>
+		<ShortDescription>Not Rated</ShortDescription>
+		<Description>Not Rated</Description>
+		<Namespace>uri://ed-fi.org/AccreditationStatusDescriptor</Namespace>
+	</AccreditationStatusDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/CertificationExamStatusDescriptor.xml
+++ b/Descriptors/CertificationExamStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CertificationExamStatusDescriptor>
 		<CodeValue>Failed</CodeValue>
 		<ShortDescription>The person has failed to pass the certification exam.</ShortDescription>

--- a/Descriptors/CertificationExamTypeDescriptor.xml
+++ b/Descriptors/CertificationExamTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CertificationExamTypeDescriptor>
 		<CodeValue>National</CodeValue>
 		<ShortDescription>Exam is for a nationally recognized certification.</ShortDescription>

--- a/Descriptors/CertificationFieldDescriptor.xml
+++ b/Descriptors/CertificationFieldDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CertificationFieldDescriptor>
 		<CodeValue>Agricultural Science</CodeValue>
 		<ShortDescription>Certification exam is on Agricultural Science</ShortDescription>

--- a/Descriptors/CertificationLevelDescriptor.xml
+++ b/Descriptors/CertificationLevelDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CertificationLevelDescriptor>
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>Certifies for administrative responsibilities.</ShortDescription>

--- a/Descriptors/CertificationRouteDescriptor.xml
+++ b/Descriptors/CertificationRouteDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CertificationRouteDescriptor>
 		<CodeValue>Alternative Program</CodeValue>
 		<ShortDescription>Certified by an alternative program.</ShortDescription>

--- a/Descriptors/CredentialEventTypeDescriptor.xml
+++ b/Descriptors/CredentialEventTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CredentialEventTypeDescriptor>
 		<CodeValue>Deprecated</CodeValue>
 		<ShortDescription>The certification of the person is deprecated.</ShortDescription>

--- a/Descriptors/CredentialStatusDescriptor.xml
+++ b/Descriptors/CredentialStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CredentialStatusDescriptor>
 		<CodeValue>Active</CodeValue>
 		<ShortDescription>The credential status is Active.</ShortDescription>

--- a/Descriptors/DegreeDescriptor.xml
+++ b/Descriptors/DegreeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<DegreeDescriptor>
 		<CodeValue>Associate's degree</CodeValue>
 		<ShortDescription>Certification requires  an Associate's degree.</ShortDescription>

--- a/Descriptors/EducatorRoleDescriptor.xml
+++ b/Descriptors/EducatorRoleDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducatorRoleDescriptor>
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>The educator is an Administrative.</ShortDescription>

--- a/Descriptors/FederalLocaleCodeDescriptor.xml
+++ b/Descriptors/FederalLocaleCodeDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<FederalLocaleCodeDescriptor>
+		<CodeValue>City</CodeValue>
+		<ShortDescription>Territory inside an urbanized area and inside a principal city.</ShortDescription>
+		<Description>Territory inside an urbanized area and inside a principal city.</Description>
+		<Namespace>uri://ed-fi.org/FederalLocaleCodeDescriptor</Namespace>
+	</FederalLocaleCodeDescriptor>
+	<FederalLocaleCodeDescriptor>
+		<CodeValue>Rural</CodeValue>
+		<ShortDescription>Census-defined rural territory.</ShortDescription>
+		<Description>Census-defined rural territory.</Description>
+		<Namespace>uri://ed-fi.org/FederalLocaleCodeDescriptor</Namespace>
+	</FederalLocaleCodeDescriptor>
+	<FederalLocaleCodeDescriptor>
+		<CodeValue>Suburb</CodeValue>
+		<ShortDescription>Territory outside a principal city and inside an urbanized area.</ShortDescription>
+		<Description>Territory outside a principal city and inside an urbanized area.</Description>
+		<Namespace>uri://ed-fi.org/FederalLocaleCodeDescriptor</Namespace>
+	</FederalLocaleCodeDescriptor>
+	<FederalLocaleCodeDescriptor>
+		<CodeValue>Town</CodeValue>
+		<ShortDescription>Territory inside an urban cluster.</ShortDescription>
+		<Description>Territory inside an urban cluster.</Description>
+		<Namespace>uri://ed-fi.org/FederalLocaleCodeDescriptor</Namespace>
+	</FederalLocaleCodeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/FundingSourceDescriptor.xml
+++ b/Descriptors/FundingSourceDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+    <FundingSourceDescriptor>
+		<CodeValue>District</CodeValue>
+		<ShortDescription>District funds.</ShortDescription>
+		<Description>Funding source is the district.</Description>
+		<Namespace>uri://ed-fi.org/FundingSourceDescriptor</Namespace>
+	</FundingSourceDescriptor>
+	<FundingSourceDescriptor>
+		<CodeValue>Federal</CodeValue>
+		<ShortDescription>Federal grant</ShortDescription>
+		<Description>Funding source is a federal authority.</Description>
+		<Namespace>uri://ed-fi.org/FundingSourceDescriptor</Namespace>
+	</FundingSourceDescriptor>
+	<FundingSourceDescriptor>
+		<CodeValue>State</CodeValue>
+		<ShortDescription>State grant</ShortDescription>
+		<Description>Funding source is the state.</Description>
+		<Namespace>uri://ed-fi.org/FundingSourceDescriptor</Namespace>
+	</FundingSourceDescriptor>
+	<FundingSourceDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other source provides funding.</ShortDescription>
+		<Description>Other source provides funding.</Description>
+		<Namespace>uri://ed-fi.org/FundingSourceDescriptor</Namespace>
+	</FundingSourceDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/InstructionalSettingDescriptor.xml
+++ b/Descriptors/InstructionalSettingDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/5.2.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/5.2.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<InstructionalSettingDescriptor>
 		<CodeValue>Classroom</CodeValue>
 		<ShortDescription>An instruction in Classroom setting is authorized.</ShortDescription>

--- a/Descriptors/LengthOfContractDescriptor.xml
+++ b/Descriptors/LengthOfContractDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<LengthOfContractDescriptor>
+		<CodeValue>6 months</CodeValue>
+		<ShortDescription>Contract is for 6 months.</ShortDescription>
+		<Description>Contract is for 6 months</Description>
+		<Namespace>uri://ed-fi.org/LengthOfContractDescriptor</Namespace>
+	</LengthOfContractDescriptor>	
+	<LengthOfContractDescriptor>
+		<CodeValue>9 months</CodeValue>
+		<ShortDescription>Contract is for 9 months</ShortDescription>
+		<Description>Contract is for 9 months</Description>
+		<Namespace>uri://ed-fi.org/LengthOfContractDescriptor</Namespace>
+	</LengthOfContractDescriptor>
+	<LengthOfContractDescriptor>
+		<CodeValue>12 months</CodeValue>
+		<ShortDescription>Contract is for 12 months</ShortDescription>
+		<Description>Contract is for 12 months</Description>
+		<Namespace>uri://ed-fi.org/LengthOfContractDescriptor</Namespace>
+	</LengthOfContractDescriptor>
+	<LengthOfContractDescriptor>
+		<CodeValue>Summer</CodeValue>
+		<ShortDescription>Contract is for only for summer</ShortDescription>
+		<Description>Contract is only for the summer</Description>
+		<Namespace>uri://ed-fi.org/LengthOfContractDescriptor</Namespace>
+	</LengthOfContractDescriptor>	
+</InterchangeDescriptors>

--- a/Descriptors/OpenStaffPositionReasonDescriptor.xml
+++ b/Descriptors/OpenStaffPositionReasonDescriptor.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<OpenStaffPositionReasonDescriptor>
+		<CodeValue>New</CodeValue>
+		<ShortDescription>A new position</ShortDescription>
+		<Description>New position</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionReasonDescriptor</Namespace>
+	</OpenStaffPositionReasonDescriptor>
+	<OpenStaffPositionReasonDescriptor>
+		<CodeValue>Replacement</CodeValue>
+		<ShortDescription>A replacement for an existing position.</ShortDescription>
+		<Description>A replacement for an existing position.</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionReasonDescriptor</Namespace>
+	</OpenStaffPositionReasonDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/SalaryTypeDescriptor.xml
+++ b/Descriptors/SalaryTypeDescriptor.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<SalaryTypeDescriptor>
+		<CodeValue>Contract</CodeValue>
+		<ShortDescription>Staff salary is based on a contract.</ShortDescription>
+		<Description>Staff salary is based on a contract.</Description>
+		<Namespace>uri://ed-fi.org/SalaryTypeDescriptor</Namespace>
+	</SalaryTypeDescriptor>
+	<SalaryTypeDescriptor>
+		<CodeValue>Full Time</CodeValue>
+		<ShortDescription>Staff salary is based on a full-time employment.</ShortDescription>
+		<Description>Staff salary is based on a full-time employment.</Description>
+		<Namespace>uri://ed-fi.org/SalaryTypeDescriptor</Namespace>
+	</SalaryTypeDescriptor>
+	<SalaryTypeDescriptor>
+		<CodeValue>Hourly</CodeValue>
+		<ShortDescription>Staff salary is based on a hourly work.</ShortDescription>
+		<Description>Staff salary is based on a hourly work.</Description>
+		<Namespace>uri://ed-fi.org/SalaryTypeDescriptor</Namespace>
+	</SalaryTypeDescriptor>
+	<SalaryTypeDescriptor>
+		<CodeValue>Part Time</CodeValue>
+		<ShortDescription>Staff salary is based on a part-time employment.</ShortDescription>
+		<Description>Staff salary is based on a part-time employment.</Description>
+		<Namespace>uri://ed-fi.org/SalaryTypeDescriptor</Namespace>
+	</SalaryTypeDescriptor>
+	<SalaryTypeDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Staff salary is based on an other option.</ShortDescription>
+		<Description>Staff salary is based on an other option.</Description>
+		<Namespace>uri://ed-fi.org/SalaryTypeDescriptor</Namespace>
+	</SalaryTypeDescriptor>
+</InterchangeDescriptors>


### PR DESCRIPTION
[DATASTD-2381] Add TPDM Descriptors, updated uri, added descriptions, alphabetized. In addition, headers for previous TPDM descriptors updated to 6.0.0 from 5.1.0

[DATASTD-2381]: https://edfi.atlassian.net/browse/DATASTD-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ