### PR TITLE
[DATASTD-2382] TPDM Recruiting - Staffing Descriptor

### DIFF
--- a/Descriptors/ApplicationSourceDescriptor.xml
+++ b/Descriptors/ApplicationSourceDescriptor.xml
@@ -67,12 +67,6 @@
 		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
 	</ApplicationSourceDescriptor>
 	<ApplicationSourceDescriptor>
-		<CodeValue>Other</CodeValue>
-		<ShortDescription>Other</ShortDescription>
-		<Description>Other</Description>
-		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
-	</ApplicationSourceDescriptor>
-	<ApplicationSourceDescriptor>
 		<CodeValue>Print Ad</CodeValue>
 		<ShortDescription>Print Ad</ShortDescription>
 		<Description>Print Advertisement</Description>
@@ -118,6 +112,12 @@
 		<CodeValue>Word of Mouth</CodeValue>
 		<ShortDescription>Word of Mouth</ShortDescription>
 		<Description>Word of Mouth</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+		<ApplicationSourceDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
 		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
 	</ApplicationSourceDescriptor>
 </InterchangeDescriptors>

--- a/Descriptors/ApplicationSourceDescriptor.xml
+++ b/Descriptors/ApplicationSourceDescriptor.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<ApplicationSourceDescriptor>
+		<CodeValue>Craigslist</CodeValue>
+		<ShortDescription>Craigslist</ShortDescription>
+		<Description>Craigslist</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>District Website</CodeValue>
+		<ShortDescription>District Website</ShortDescription>
+		<Description>District Website</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Email</CodeValue>
+		<ShortDescription>Email</ShortDescription>
+		<Description>Email</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Employee</CodeValue>
+		<ShortDescription>Employee</ShortDescription>
+		<Description>Current Employee</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Facebook</CodeValue>
+		<ShortDescription>Facebook</ShortDescription>
+		<Description>Facebook</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Indeed</CodeValue>
+		<ShortDescription>Indeed</ShortDescription>
+		<Description>Indeed</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Instagram</CodeValue>
+		<ShortDescription>Instagram</ShortDescription>
+		<Description>Instagram</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Job Fair</CodeValue>
+		<ShortDescription>Job Fair</ShortDescription>
+		<Description>Community Job Fair</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>K12jobs.com</CodeValue>
+		<ShortDescription>K12jobs.com</ShortDescription>
+		<Description>K12jobs.com</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>LinkedIn</CodeValue>
+		<ShortDescription>LinkedIn</ShortDescription>
+		<Description>LinkedIn</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Newspaper</CodeValue>
+		<ShortDescription>Newspaper</ShortDescription>
+		<Description>Newspaper</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Print Ad</CodeValue>
+		<ShortDescription>Print Ad</ShortDescription>
+		<Description>Print Advertisement</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Radio</CodeValue>
+		<ShortDescription>Radio</ShortDescription>
+		<Description>Radio</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Teachers-Teachers.com</CodeValue>
+		<ShortDescription>Teachers-Teachers.com</ShortDescription>
+		<Description>Teachers-Teachers.com</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>TFANet</CodeValue>
+		<ShortDescription>TFANet</ShortDescription>
+		<Description>TFANet Job Board</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Twitter</CodeValue>
+		<ShortDescription>Twitter</ShortDescription>
+		<Description>Twitter</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>University</CodeValue>
+		<ShortDescription>University</ShortDescription>
+		<Description>University Job Fair</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>USTeach.com</CodeValue>
+		<ShortDescription>USTeach.com</ShortDescription>
+		<Description>USTeach.com</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+	<ApplicationSourceDescriptor>
+		<CodeValue>Word of Mouth</CodeValue>
+		<ShortDescription>Word of Mouth</ShortDescription>
+		<Description>Word of Mouth</Description>
+		<Namespace>uri://ed-fi.org/ApplicationSourceDescriptor</Namespace>
+	</ApplicationSourceDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/ApplicationStatusDescriptor.xml
+++ b/Descriptors/ApplicationStatusDescriptor.xml
@@ -19,15 +19,21 @@
 		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
 	</ApplicationStatusDescriptor>
 	<ApplicationStatusDescriptor>
-		<CodeValue>In Progress</CodeValue>
-		<ShortDescription>In Progress</ShortDescription>
-		<Description>In Progress</Description>
+		<CodeValue>Incomplete</CodeValue>
+		<ShortDescription>Incomplete</ShortDescription>
+		<Description>Incomplete</Description>
 		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
 	</ApplicationStatusDescriptor>
-	<ApplicationStatusDescriptor>
+		<ApplicationStatusDescriptor>
 		<CodeValue>Interview</CodeValue>
 		<ShortDescription>Interview</ShortDescription>
 		<Description>In Person Interview</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>In Progress</CodeValue>
+		<ShortDescription>In Progress</ShortDescription>
+		<Description>In Progress</Description>
 		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
 	</ApplicationStatusDescriptor>
 	<ApplicationStatusDescriptor>
@@ -58,12 +64,6 @@
 		<CodeValue>Rejected</CodeValue>
 		<ShortDescription>Rejected</ShortDescription>
 		<Description>Rejected</Description>
-		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
-	</ApplicationStatusDescriptor>
-	<ApplicationStatusDescriptor>
-		<CodeValue>Incomplete</CodeValue>
-		<ShortDescription>Incomplete</ShortDescription>
-		<Description>Incomplete</Description>
 		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
 	</ApplicationStatusDescriptor>
 	<ApplicationStatusDescriptor>

--- a/Descriptors/ApplicationStatusDescriptor.xml
+++ b/Descriptors/ApplicationStatusDescriptor.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<ApplicationStatusDescriptor>
+		<CodeValue>Accepted</CodeValue>
+		<ShortDescription>Accepted</ShortDescription>
+		<Description>Offer accepted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Candidate Pool</CodeValue>
+		<ShortDescription>Candidate Pool</ShortDescription>
+		<Description>Candidate Pool</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Extended</CodeValue>
+		<ShortDescription>Extended</ShortDescription>
+		<Description>Offer extended</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>In Progress</CodeValue>
+		<ShortDescription>In Progress</ShortDescription>
+		<Description>In Progress</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Interview</CodeValue>
+		<ShortDescription>Interview</ShortDescription>
+		<Description>In Person Interview</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>No response</CodeValue>
+		<ShortDescription>No response</ShortDescription>
+		<Description>No response from applicant</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Phone Interview</CodeValue>
+		<ShortDescription>Phone Interview</ShortDescription>
+		<Description>Phone Interview</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Pre-screened</CodeValue>
+		<ShortDescription>Pre-screened</ShortDescription>
+		<Description>Pre-screened</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Recommendations</CodeValue>
+		<ShortDescription>Recommendations</ShortDescription>
+		<Description>Recommendations submitted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Rejected</CodeValue>
+		<ShortDescription>Rejected</ShortDescription>
+		<Description>Rejected</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Incomplete</CodeValue>
+		<ShortDescription>Incomplete</ShortDescription>
+		<Description>Incomplete</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Sample Lesson</CodeValue>
+		<ShortDescription>Sample Lesson</ShortDescription>
+		<Description>Sample Lesson</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>School Visit</CodeValue>
+		<ShortDescription>School Visit</ShortDescription>
+		<Description>School Visit</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Selected</CodeValue>
+		<ShortDescription>Selected</ShortDescription>
+		<Description>Selected</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Submitted</CodeValue>
+		<ShortDescription>Submitted</ShortDescription>
+		<Description>Submitted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Video</CodeValue>
+		<ShortDescription>Video</ShortDescription>
+		<Description>Video Submitted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+	<ApplicationStatusDescriptor>
+		<CodeValue>Withdrawn</CodeValue>
+		<ShortDescription>Withdrawn</ShortDescription>
+		<Description>Withdrawn</Description>
+		<Namespace>uri://ed-fi.org/ApplicationStatusDescriptor</Namespace>
+	</ApplicationStatusDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/BackgroundCheckStatusDescriptor.xml
+++ b/Descriptors/BackgroundCheckStatusDescriptor.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+    <BackgroundCheckStatusDescriptor>
+		<CodeValue>Eligible</CodeValue>
+		<ShortDescription>Eligible</ShortDescription>
+		<Description>Eligible</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+	<BackgroundCheckStatusDescriptor>
+		<CodeValue>Employer Review</CodeValue>
+		<ShortDescription>Employer Review</ShortDescription>
+		<Description>Employer processing results</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+	<BackgroundCheckStatusDescriptor>
+		<CodeValue>Not Eligible</CodeValue>
+		<ShortDescription>Not Eligible</ShortDescription>
+		<Description>Not Eligible</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+	<BackgroundCheckStatusDescriptor>
+		<CodeValue>Started</CodeValue>
+		<ShortDescription>Started</ShortDescription>
+		<Description>Some requirements submitted for review</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+	<BackgroundCheckStatusDescriptor>
+		<CodeValue>Submitted</CodeValue>
+		<ShortDescription>Submitted</ShortDescription>
+		<Description>All requirements submitted for review</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+	<BackgroundCheckStatusDescriptor>
+		<CodeValue>Waiting</CodeValue>
+		<ShortDescription>Waiting</ShortDescription>
+		<Description>Awaiting response from authorities</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckStatusDescriptor</Namespace>
+	</BackgroundCheckStatusDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/BackgroundCheckTypeDescriptor.xml
+++ b/Descriptors/BackgroundCheckTypeDescriptor.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+    <BackgroundCheckTypeDescriptor>
+		<CodeValue>City</CodeValue>
+		<ShortDescription>City</ShortDescription>
+		<Description>City</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>County</CodeValue>
+		<ShortDescription>County</ShortDescription>
+		<Description>County</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>Federal</CodeValue>
+		<ShortDescription>Federal</ShortDescription>
+		<Description>Federal</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>State</CodeValue>
+		<ShortDescription>State</ShortDescription>
+		<Description>State</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+    <BackgroundCheckTypeDescriptor>
+		<CodeValue>FP City</CodeValue>
+		<ShortDescription>FP City</ShortDescription>
+		<Description>City</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>FP County</CodeValue>
+		<ShortDescription>FP County</ShortDescription>
+		<Description>County</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>FP Federal</CodeValue>
+		<ShortDescription>FP Federal</ShortDescription>
+		<Description>Federal</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>FP State</CodeValue>
+		<ShortDescription>FP State</ShortDescription>
+		<Description>State</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+	<BackgroundCheckTypeDescriptor>
+		<CodeValue>Questionnaire</CodeValue>
+		<ShortDescription>Questionnaire</ShortDescription>
+		<Description>Moral Questionnaire</Description>
+		<Namespace>uri://ed-fi.org/BackgroundCheckTypeDescriptor</Namespace>
+	</BackgroundCheckTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/GenderDescriptor.xml
+++ b/Descriptors/GenderDescriptor.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<GenderDescriptor>
+		<CodeValue>Female</CodeValue>
+		<ShortDescription>Female</ShortDescription>
+		<Description>Female</Description>
+		<Namespace>uri://ed-fi.org/GenderDescriptor</Namespace>
+	</GenderDescriptor>
+	<GenderDescriptor>
+		<CodeValue>Male</CodeValue>
+		<ShortDescription>Male</ShortDescription>
+		<Description>Male</Description>
+		<Namespace>uri://ed-fi.org/GenderDescriptor</Namespace>
+	</GenderDescriptor>
+	<GenderDescriptor>
+		<CodeValue>Not Selected</CodeValue>
+		<ShortDescription>Not Selected</ShortDescription>
+		<Description>Not Selected</Description>
+		<Namespace>uri://ed-fi.org/GenderDescriptor</Namespace>
+	</GenderDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/HireStatusDescriptor.xml
+++ b/Descriptors/HireStatusDescriptor.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<HireStatusDescriptor>
+		<CodeValue>Applied</CodeValue>
+		<ShortDescription>Applied</ShortDescription>
+		<Description>Application made</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Hired</CodeValue>
+		<ShortDescription>Hired</ShortDescription>
+		<Description>Applicant was hired</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Not Accepted</CodeValue>
+		<ShortDescription>Not Accepted</ShortDescription>
+		<Description>Offer not accepted</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Offered</CodeValue>
+		<ShortDescription>Offered</ShortDescription>
+		<Description>Offer made for employment</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Recommended</CodeValue>
+		<ShortDescription>Recommended</ShortDescription>
+		<Description>Recommended for hire</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Rejected</CodeValue>
+		<ShortDescription>Rejected</ShortDescription>
+		<Description>Rejected by district</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+	<HireStatusDescriptor>
+		<CodeValue>Withdrawn</CodeValue>
+		<ShortDescription>Withdrawn</ShortDescription>
+		<Description>Application withdrawn by applicant</Description>
+		<Namespace>uri://ed-fi.org/HireStatusDescriptor</Namespace>
+	</HireStatusDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/HiringSourceDescriptor.xml
+++ b/Descriptors/HiringSourceDescriptor.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<HiringSourceDescriptor>
+		<CodeValue>District</CodeValue>
+		<ShortDescription>District</ShortDescription>
+		<Description>District</Description>
+		<Namespace>uri://ed-fi.org/HiringSourceDescriptor</Namespace>
+	</HiringSourceDescriptor>
+	<HiringSourceDescriptor>
+		<CodeValue>School</CodeValue>
+		<ShortDescription>School</ShortDescription>
+		<Description>School</Description>
+		<Namespace>uri://ed-fi.org/HiringSourceDescriptor</Namespace>
+	</HiringSourceDescriptor>
+		<HiringSourceDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/HiringSourceDescriptor</Namespace>
+	</HiringSourceDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/ProfessionalDevelopmentOfferedByDescriptor.xml
+++ b/Descriptors/ProfessionalDevelopmentOfferedByDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+    <ProfessionalDevelopmentOfferedByDescriptor>
+		<CodeValue>District</CodeValue>
+		<ShortDescription>District</ShortDescription>
+		<Description>District</Description>
+		<Namespace>uri://ed-fi.org/ProfessionalDevelopmentOfferedByDescriptor</Namespace>
+	</ProfessionalDevelopmentOfferedByDescriptor>
+		<ProfessionalDevelopmentOfferedByDescriptor>
+		<CodeValue>Educator Preparation Provider</CodeValue>
+		<ShortDescription>Educator Preparation Provider</ShortDescription>
+		<Description>Educator Preparation Provider</Description>
+		<Namespace>uri://ed-fi.org/ProfessionalDevelopmentOfferedByDescriptor</Namespace>
+	</ProfessionalDevelopmentOfferedByDescriptor>
+	<ProfessionalDevelopmentOfferedByDescriptor>
+		<CodeValue>School</CodeValue>
+		<ShortDescription>School</ShortDescription>
+		<Description>School</Description>
+		<Namespace>uri://ed-fi.org/ProfessionalDevelopmentOfferedByDescriptor</Namespace>
+	</ProfessionalDevelopmentOfferedByDescriptor>
+	<ProfessionalDevelopmentOfferedByDescriptor>
+		<CodeValue>State</CodeValue>
+		<ShortDescription>State</ShortDescription>
+		<Description>State</Description>
+		<Namespace>uri://ed-fi.org/ProfessionalDevelopmentOfferedByDescriptor</Namespace>
+	</ProfessionalDevelopmentOfferedByDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/RecruitmentEventTypeDescriptor.xml
+++ b/Descriptors/RecruitmentEventTypeDescriptor.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>Career Fair</CodeValue>
+		<ShortDescription>Career Fair</ShortDescription>
+		<Description>Career Fair</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>Community College Recruitment</CodeValue>
+		<ShortDescription>Community College Recruitment</ShortDescription>
+		<Description>Community College Recruitment</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>Community Service Event</CodeValue>
+		<ShortDescription>Community Service Event</ShortDescription>
+		<Description>Community Service Event</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>Conference</CodeValue>
+		<ShortDescription>Conference</ShortDescription>
+		<Description>Conference</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>High School Recruitment</CodeValue>
+		<ShortDescription>High School Recruitment</ShortDescription>
+		<Description>High School Recruitment</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>University Event</CodeValue>
+		<ShortDescription>University Event</ShortDescription>
+		<Description>University Event</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+	<RecruitmentEventTypeDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/RecruitmentEventTypeDescriptor</Namespace>
+	</RecruitmentEventTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/WithdrawReasonDescriptor.xml
+++ b/Descriptors/WithdrawReasonDescriptor.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<WithdrawReasonDescriptor>
+		<CodeValue>Displeased</CodeValue>
+		<ShortDescription>Displeased</ShortDescription>
+		<Description>Displeased with the offer or hiring process</Description>
+		<Namespace>uri://ed-fi.org/WithdrawReasonDescriptor</Namespace>
+	</WithdrawReasonDescriptor>
+	<WithdrawReasonDescriptor>
+		<CodeValue>Dropped out</CodeValue>
+		<ShortDescription>Dropped out</ShortDescription>
+		<Description>No longer searching</Description>
+		<Namespace>uri://ed-fi.org/WithdrawReasonDescriptor</Namespace>
+	</WithdrawReasonDescriptor>
+	<WithdrawReasonDescriptor>
+		<CodeValue>Hired Elsewhere</CodeValue>
+		<ShortDescription>Hired Elsewhere</ShortDescription>
+		<Description>Accepted other offer</Description>
+		<Namespace>uri://ed-fi.org/WithdrawReasonDescriptor</Namespace>
+	</WithdrawReasonDescriptor>
+	<WithdrawReasonDescriptor>
+		<CodeValue>Not Eligible</CodeValue>
+		<ShortDescription>Not Eligible</ShortDescription>
+		<Description>Unable to submit required documents</Description>
+		<Namespace>uri://ed-fi.org/WithdrawReasonDescriptor</Namespace>
+	</WithdrawReasonDescriptor>
+	<WithdrawReasonDescriptor>
+		<CodeValue>Unknown</CodeValue>
+		<ShortDescription>Unknown</ShortDescription>
+		<Description>Unknown reason</Description>
+		<Namespace>uri://ed-fi.org/WithdrawReasonDescriptor</Namespace>
+	</WithdrawReasonDescriptor>
+</InterchangeDescriptors>


### PR DESCRIPTION
[DATASTD-2382] Transferred the TPDM Recruiting and Staffing Related Descriptors. Updated header to 6.0.0 and uri, alphabetized

[DATASTD-2382]: https://edfi.atlassian.net/browse/DATASTD-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ