### PR TITLE
[DATASTD-2388] Move additional TPDM descriptors

### DIFF
--- a/Descriptors/AidTypeDescriptor.xml
+++ b/Descriptors/AidTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<AidTypeDescriptor>
 		<CodeValue>Assistantships</CodeValue>
 		<ShortDescription>Assistantships</ShortDescription>

--- a/Descriptors/AidTypeDescriptor.xml
+++ b/Descriptors/AidTypeDescriptor.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<AidTypeDescriptor>
+		<CodeValue>Assistantships</CodeValue>
+		<ShortDescription>Assistantships</ShortDescription>
+		<Description>Assistantships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Federal Scholarships</CodeValue>
+		<ShortDescription>Federal Scholarships</ShortDescription>
+		<Description>Federal Scholarships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Federal Subsidized Loans</CodeValue>
+		<ShortDescription>Federal Subsidized Loans</ShortDescription>
+		<Description>Federal Subsidized Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Federal Unsubsidized Loans</CodeValue>
+		<ShortDescription>Federal Unsubsidized Loans</ShortDescription>
+		<Description>Federal Unsubsidized Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Federal Work Study</CodeValue>
+		<ShortDescription>Federal Work Study</ShortDescription>
+		<Description>Federal Work Study</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Institutional Grants</CodeValue>
+		<ShortDescription>Institutional Grants</ShortDescription>
+		<Description>Institutional Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Institutional Loans</CodeValue>
+		<ShortDescription>Institutional Loans</ShortDescription>
+		<Description>Institutional Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Institutional Scholarships</CodeValue>
+		<ShortDescription>Institutional Scholarships</ShortDescription>
+		<Description>Institutional Scholarships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Loan Forgiveness</CodeValue>
+		<ShortDescription>Loan Forgiveness</ShortDescription>
+		<Description>Loan Forgiveness</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Parent PLUS Loans</CodeValue>
+		<ShortDescription>Parent PLUS Loans</ShortDescription>
+		<Description>Parent PLUS Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Pell Grants</CodeValue>
+		<ShortDescription>Pell Grants</ShortDescription>
+		<Description>Pell Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Private Grants</CodeValue>
+		<ShortDescription>Private Grants</ShortDescription>
+		<Description>Private Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Private Loans</CodeValue>
+		<ShortDescription>Private Loans</ShortDescription>
+		<Description>Private Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Private Scholarships</CodeValue>
+		<ShortDescription>Private Scholarships</ShortDescription>
+		<Description>Private Scholarships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>State and Local Grants</CodeValue>
+		<ShortDescription>State and Local Grants</ShortDescription>
+		<Description>State and Local Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>State and Local Scholarships</CodeValue>
+		<ShortDescription>State and Local Scholarships</ShortDescription>
+		<Description>State and Local Scholarships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>State Loans</CodeValue>
+		<ShortDescription>State Loans</ShortDescription>
+		<Description>State Loans</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>State Work</CodeValue>
+		<ShortDescription>State Work</ShortDescription>
+		<Description>State Work</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Teach Grants</CodeValue>
+		<ShortDescription>Teach Grants</ShortDescription>
+		<Description>Teach Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Tuition Reimbursements</CodeValue>
+		<ShortDescription>Tuition Reimbursements</ShortDescription>
+		<Description>Tuition Reimbursements</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+		<AidTypeDescriptor>
+		<CodeValue>Other Federal Grants</CodeValue>
+		<ShortDescription>Other Federal Grants</ShortDescription>
+		<Description>Other Federal Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Other Grants</CodeValue>
+		<ShortDescription>Other Grants</ShortDescription>
+		<Description>Other Grants</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Other On-Campus Work</CodeValue>
+		<ShortDescription>Other On-Campus Work</ShortDescription>
+		<Description>Other On-Campus Work</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+	<AidTypeDescriptor>
+		<CodeValue>Other Scholarships</CodeValue>
+		<ShortDescription>Other Scholarships</ShortDescription>
+		<Description>Other Scholarships</Description>
+		<Namespace>uri://ed-fi.org/AidTypeDescriptor</Namespace>
+	</AidTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/ApplicationEventResultDescriptor.xml
+++ b/Descriptors/ApplicationEventResultDescriptor.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<ApplicationEventResultDescriptor>
+		<CodeValue>Advance</CodeValue>
+		<ShortDescription>Advance</ShortDescription>
+		<Description>Advance to next stage</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+	<ApplicationEventResultDescriptor>
+		<CodeValue>Highly Recommend</CodeValue>
+		<ShortDescription>Highly Recommend</ShortDescription>
+		<Description>Advance to next stage, highly recommended</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+	<ApplicationEventResultDescriptor>
+		<CodeValue>NA</CodeValue>
+		<ShortDescription>NA</ShortDescription>
+		<Description>Not Available</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+	<ApplicationEventResultDescriptor>
+		<CodeValue>Recommend</CodeValue>
+		<ShortDescription>Recommend</ShortDescription>
+		<Description>Advance to next stage, recommended</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+	<ApplicationEventResultDescriptor>
+		<CodeValue>Reservations</CodeValue>
+		<ShortDescription>Reservations</ShortDescription>
+		<Description>Advance to next stage with reservations</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+	<ApplicationEventResultDescriptor>
+		<CodeValue>Screen out</CodeValue>
+		<ShortDescription>Screen out</ShortDescription>
+		<Description>Screen out</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventResultDescriptor</Namespace>
+	</ApplicationEventResultDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/ApplicationEventResultDescriptor.xml
+++ b/Descriptors/ApplicationEventResultDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<ApplicationEventResultDescriptor>
 		<CodeValue>Advance</CodeValue>
 		<ShortDescription>Advance</ShortDescription>

--- a/Descriptors/ApplicationEventTypeDescriptor.xml
+++ b/Descriptors/ApplicationEventTypeDescriptor.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<ApplicationEventTypeDescriptor>
+		<CodeValue>Accepted</CodeValue>
+		<ShortDescription>Accepted</ShortDescription>
+		<Description>Offer accepted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Communication</CodeValue>
+		<ShortDescription>Communication</ShortDescription>
+		<Description>Contact with the applicant</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Extended</CodeValue>
+		<ShortDescription>Extended</ShortDescription>
+		<Description>Offer extended</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Interview</CodeValue>
+		<ShortDescription>Interview</ShortDescription>
+		<Description>In Person Interview</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>No response</CodeValue>
+		<ShortDescription>No response</ShortDescription>
+		<Description>Discarded due to no response from applicant</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Phone Interview</CodeValue>
+		<ShortDescription>Phone Interview</ShortDescription>
+		<Description>Phone Interview</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Pre-screened</CodeValue>
+		<ShortDescription>Pre-screened</ShortDescription>
+		<Description>Pre-screened</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Recommendations</CodeValue>
+		<ShortDescription>Recommendations</ShortDescription>
+		<Description>Recommendations submitted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Rejected</CodeValue>
+		<ShortDescription>Rejected</ShortDescription>
+		<Description>Offer rejected</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Sample Lesson</CodeValue>
+		<ShortDescription>Sample Lesson</ShortDescription>
+		<Description>Sample Lesson</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>School Visit</CodeValue>
+		<ShortDescription>School Visit</ShortDescription>
+		<Description>School Visit</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Selected</CodeValue>
+		<ShortDescription>Selected</ShortDescription>
+		<Description>Selected</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Video</CodeValue>
+		<ShortDescription>Video</ShortDescription>
+		<Description>Video Submitted</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+	<ApplicationEventTypeDescriptor>
+		<CodeValue>Withdrawn</CodeValue>
+		<ShortDescription>Withdrawn</ShortDescription>
+		<Description>Withdrawn</Description>
+		<Namespace>uri://ed-fi.org/ApplicationEventTypeDescriptor</Namespace>
+	</ApplicationEventTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/ApplicationEventTypeDescriptor.xml
+++ b/Descriptors/ApplicationEventTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 <ApplicationEventTypeDescriptor>
 		<CodeValue>Accepted</CodeValue>
 		<ShortDescription>Accepted</ShortDescription>

--- a/Descriptors/CandidateCharacteristicDescriptor.xml
+++ b/Descriptors/CandidateCharacteristicDescriptor.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Asylee</CodeValue>
+		<ShortDescription>Asylee</ShortDescription>
+		<Description>Asylee</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Displaced Homemaker</CodeValue>
+		<ShortDescription>Displaced Homemaker</ShortDescription>
+		<Description>Displaced Homemaker</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>First Generation College Student</CodeValue>
+		<ShortDescription>First Generation College Student</ShortDescription>
+		<Description>First Generation College Student</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Foster Care</CodeValue>
+		<ShortDescription>Foster Care</ShortDescription>
+		<Description>Foster Care</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Homeless</CodeValue>
+		<ShortDescription>Homeless</ShortDescription>
+		<Description>Homeless</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Immigrant</CodeValue>
+		<ShortDescription>Immigrant</ShortDescription>
+		<Description>Immigrant</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Migrant</CodeValue>
+		<ShortDescription>Migrant</ShortDescription>
+		<Description>Migrant</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Neglected or Delinquent</CodeValue>
+		<ShortDescription>Neglected or Delinquent</ShortDescription>
+		<Description>Neglected or Delinquent</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Parent in Military</CodeValue>
+		<ShortDescription>Parent in Military</ShortDescription>
+		<Description>Parent in Military</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Pregnant</CodeValue>
+		<ShortDescription>Pregnant</ShortDescription>
+		<Description>Pregnant</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Refugee</CodeValue>
+		<ShortDescription>Refugee</ShortDescription>
+		<Description>Refugee</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Runaway</CodeValue>
+		<ShortDescription>Runaway</ShortDescription>
+		<Description>Runaway</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Section 504 Handicapped</CodeValue>
+		<ShortDescription>Section 504 Handicapped</ShortDescription>
+		<Description>Section 504 Handicapped</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Single Parent</CodeValue>
+		<ShortDescription>Single Parent</ShortDescription>
+		<Description>Single Parent</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Unaccompanied Youth</CodeValue>
+		<ShortDescription>Unaccompanied Youth</ShortDescription>
+		<Description>Unaccompanied Youth</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+	<CandidateCharacteristicDescriptor>
+		<CodeValue>Veteran</CodeValue>
+		<ShortDescription>Veteran</ShortDescription>
+		<Description>Veteran</Description>
+		<Namespace>uri://ed-fi.org/CandidateCharacteristicDescriptor</Namespace>
+	</CandidateCharacteristicDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/CandidateCharacteristicDescriptor.xml
+++ b/Descriptors/CandidateCharacteristicDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<CandidateCharacteristicDescriptor>
 		<CodeValue>Asylee</CodeValue>
 		<ShortDescription>Asylee</ShortDescription>

--- a/Descriptors/EPPDegreeTypeDescriptor.xml
+++ b/Descriptors/EPPDegreeTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EPPDegreeTypeDescriptor>
 		<CodeValue>Bachelor of Arts</CodeValue>
 		<ShortDescription>Bachelor of Arts</ShortDescription>

--- a/Descriptors/EPPDegreeTypeDescriptor.xml
+++ b/Descriptors/EPPDegreeTypeDescriptor.xml
@@ -43,8 +43,8 @@
 		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
 	</EPPDegreeTypeDescriptor>
 	<EPPDegreeTypeDescriptor>
-		<CodeValue>Master of Science in Education</CodeValue>
-		<ShortDescription>Master of Science in Education</ShortDescription>
+		<CodeValue>Master of Education</CodeValue>
+		<ShortDescription>Master of Education</ShortDescription>
 		<Description>Master of Science in Education</Description>
 		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
 	</EPPDegreeTypeDescriptor>

--- a/Descriptors/EPPDegreeTypeDescriptor.xml
+++ b/Descriptors/EPPDegreeTypeDescriptor.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Bachelor of Arts</CodeValue>
+		<ShortDescription>Bachelor of Arts</ShortDescription>
+		<Description>Bachelor of Arts</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Bachelor of Science</CodeValue>
+		<ShortDescription>Bachelor of Science</ShortDescription>
+		<Description>Bachelor of Science</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+		<EPPDegreeTypeDescriptor>
+		<CodeValue>Doctor of Philosophy</CodeValue>
+		<ShortDescription>Doctor of Philosophy</ShortDescription>
+		<Description>Doctor of Philosophy</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+		<EPPDegreeTypeDescriptor>
+		<CodeValue>Educational Doctorate</CodeValue>
+		<ShortDescription>Educational Doctorate</ShortDescription>
+		<Description>Educational Doctorate</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Educational Specialist</CodeValue>
+		<ShortDescription>Educational Specialist</ShortDescription>
+		<Description>Educational Specialist</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Master of Arts</CodeValue>
+		<ShortDescription>Master of Arts</ShortDescription>
+		<Description>Master of Arts</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Master of Education</CodeValue>
+		<ShortDescription>Master of Education</ShortDescription>
+		<Description>Master of Education</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Master of Science</CodeValue>
+		<ShortDescription>Master of Science</ShortDescription>
+		<Description>Master of Science</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/EPPDegreeTypeDescriptor.xml
+++ b/Descriptors/EPPDegreeTypeDescriptor.xml
@@ -36,16 +36,16 @@
 		<Description>Master of Arts</Description>
 		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
 	</EPPDegreeTypeDescriptor>
-	<EPPDegreeTypeDescriptor>
-		<CodeValue>Master of Education</CodeValue>
-		<ShortDescription>Master of Education</ShortDescription>
-		<Description>Master of Education</Description>
-		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
-	</EPPDegreeTypeDescriptor>
-	<EPPDegreeTypeDescriptor>
+		<EPPDegreeTypeDescriptor>
 		<CodeValue>Master of Science</CodeValue>
 		<ShortDescription>Master of Science</ShortDescription>
 		<Description>Master of Science</Description>
+		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
+	</EPPDegreeTypeDescriptor>
+	<EPPDegreeTypeDescriptor>
+		<CodeValue>Master of Science in Education</CodeValue>
+		<ShortDescription>Master of Science in Education</ShortDescription>
+		<Description>Master of Science in Education</Description>
 		<Namespace>uri://ed-fi.org/EPPDegreeTypeDescriptor</Namespace>
 	</EPPDegreeTypeDescriptor>
 	<EPPDegreeTypeDescriptor>

--- a/Descriptors/EPPProgramPathwayDescriptor.xml
+++ b/Descriptors/EPPProgramPathwayDescriptor.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<EPPProgramPathwayDescriptor>
+		<CodeValue>Fellowship</CodeValue>
+		<ShortDescription>Fellowship</ShortDescription>
+		<Description>Fellowship</Description>
+		<Namespace>uri://ed-fi.org/EPPProgramPathwayDescriptor</Namespace>
+	</EPPProgramPathwayDescriptor>
+	<EPPProgramPathwayDescriptor>
+		<CodeValue>Internship</CodeValue>
+		<ShortDescription>Internship</ShortDescription>
+		<Description>Internship</Description>
+		<Namespace>uri://ed-fi.org/EPPProgramPathwayDescriptor</Namespace>
+	</EPPProgramPathwayDescriptor>
+	<EPPProgramPathwayDescriptor>
+		<CodeValue>Residency</CodeValue>
+		<ShortDescription>Residency</ShortDescription>
+		<Description>Residency</Description>
+		<Namespace>uri://ed-fi.org/EPPProgramPathwayDescriptor</Namespace>
+	</EPPProgramPathwayDescriptor>
+	<EPPProgramPathwayDescriptor>
+		<CodeValue>Traditional</CodeValue>
+		<ShortDescription>Traditional</ShortDescription>
+		<Description>Traditional</Description>
+		<Namespace>uri://ed-fi.org/EPPProgramPathwayDescriptor</Namespace>
+	</EPPProgramPathwayDescriptor>
+	<EPPProgramPathwayDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/EPPProgramPathwayDescriptor</Namespace>
+	</EPPProgramPathwayDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/EPPProgramPathwayDescriptor.xml
+++ b/Descriptors/EPPProgramPathwayDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EPPProgramPathwayDescriptor>
 		<CodeValue>Fellowship</CodeValue>
 		<ShortDescription>Fellowship</ShortDescription>

--- a/Descriptors/EducatorPreparationProgramTypeDescriptor.xml
+++ b/Descriptors/EducatorPreparationProgramTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EducatorPreparationProgramTypeDescriptor>
 		<CodeValue>Alternate</CodeValue>
 		<ShortDescription>Alternate</ShortDescription>

--- a/Descriptors/EducatorPreparationProgramTypeDescriptor.xml
+++ b/Descriptors/EducatorPreparationProgramTypeDescriptor.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alternate</CodeValue>
+		<ShortDescription>Alternate</ShortDescription>
+		<Description>Alternate</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+    	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt ACT</CodeValue>
+		<ShortDescription>Alt ACT</ShortDescription>
+		<Description>Alt ACT-Houston @ Dallas</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt AmeriCorps</CodeValue>
+		<ShortDescription>Alt AmeriCorps</ShortDescription>
+		<Description>Alt AmeriCorps</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt ECAP</CodeValue>
+		<ShortDescription>Alt ECAP</ShortDescription>
+		<Description>Alt ECAP</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt iTeach</CodeValue>
+		<ShortDescription>Alt iTeach</ShortDescription>
+		<Description>Alt iTeach Texas</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt Region</CodeValue>
+		<ShortDescription>Alt Region</ShortDescription>
+		<Description>Alt Region 11</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt Texas</CodeValue>
+		<ShortDescription>Alt Texas</ShortDescription>
+		<Description>Alt Texas Teachers</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt TFA</CodeValue>
+		<ShortDescription>Alt TFA</ShortDescription>
+		<Description>Alt TFA</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt TNTP</CodeValue>
+		<ShortDescription>Alt TNTP</ShortDescription>
+		<Description>Alt Teaching Fellow</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt Web</CodeValue>
+		<ShortDescription>Alt Web</ShortDescription>
+		<Description>Alt Web Centric</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+		<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Alt Other</CodeValue>
+		<ShortDescription>Alt Other</ShortDescription>
+		<Description>Alt Other</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Traditional</CodeValue>
+		<ShortDescription>Traditional</ShortDescription>
+		<Description>Traditional Certification Program</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+	<EducatorPreparationProgramTypeDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other certification program</Description>
+		<Namespace>uri://ed-fi.org/EducatorPreparationProgramTypeDescriptor</Namespace>
+	</EducatorPreparationProgramTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/EnglishLanguageExamDescriptor.xml
+++ b/Descriptors/EnglishLanguageExamDescriptor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<EnglishLanguageExamDescriptor>
+		<CodeValue>Fail</CodeValue>
+		<ShortDescription>Fail</ShortDescription>
+		<Description>Fail</Description>
+		<Namespace>uri://ed-fi.org/EnglishLanguageExamDescriptor</Namespace>
+	</EnglishLanguageExamDescriptor>
+	<EnglishLanguageExamDescriptor>
+		<CodeValue>N/A</CodeValue>
+		<ShortDescription>N/A</ShortDescription>
+		<Description>N/A</Description>
+		<Namespace>uri://ed-fi.org/EnglishLanguageExamDescriptor</Namespace>
+	</EnglishLanguageExamDescriptor>
+	<EnglishLanguageExamDescriptor>
+		<CodeValue>Pass</CodeValue>
+		<ShortDescription>Pass</ShortDescription>
+		<Description>Pass</Description>
+		<Namespace>uri://ed-fi.org/EnglishLanguageExamDescriptor</Namespace>
+	</EnglishLanguageExamDescriptor>
+	<EnglishLanguageExamDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/EnglishLanguageExamDescriptor</Namespace>
+	</EnglishLanguageExamDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/EnglishLanguageExamDescriptor.xml
+++ b/Descriptors/EnglishLanguageExamDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<EnglishLanguageExamDescriptor>
 		<CodeValue>Fail</CodeValue>
 		<ShortDescription>Fail</ShortDescription>

--- a/Descriptors/FieldworkTypeDescriptor.xml
+++ b/Descriptors/FieldworkTypeDescriptor.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<FieldworkTypeDescriptor>
+		<CodeValue>Clinical Experience</CodeValue>
+		<ShortDescription>Clinical Experience</ShortDescription>
+		<Description>Clinical Experience</Description>
+		<Namespace>uri://ed-fi.org/FieldworkTypeDescriptor</Namespace>
+	</FieldworkTypeDescriptor>
+	<FieldworkTypeDescriptor>
+		<CodeValue>Field Placement</CodeValue>
+		<ShortDescription>Field Placement</ShortDescription>
+		<Description>Field Placement</Description>
+		<Namespace>uri://ed-fi.org/FieldworkTypeDescriptor</Namespace>
+	</FieldworkTypeDescriptor>
+	<FieldworkTypeDescriptor>
+		<CodeValue>Internship</CodeValue>
+		<ShortDescription>Internship</ShortDescription>
+		<Description>Internship</Description>
+		<Namespace>uri://ed-fi.org/FieldworkTypeDescriptor</Namespace>
+	</FieldworkTypeDescriptor>
+	<FieldworkTypeDescriptor>
+		<CodeValue>Residential Program</CodeValue>
+		<ShortDescription>Residential Program</ShortDescription>
+		<Description>Residential Program</Description>
+		<Namespace>uri://ed-fi.org/FieldworkTypeDescriptor</Namespace>
+	</FieldworkTypeDescriptor>
+	<FieldworkTypeDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/FieldworkTypeDescriptor</Namespace>
+	</FieldworkTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/FieldworkTypeDescriptor.xml
+++ b/Descriptors/FieldworkTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<FieldworkTypeDescriptor>
 		<CodeValue>Clinical Experience</CodeValue>
 		<ShortDescription>Clinical Experience</ShortDescription>

--- a/Descriptors/OpenStaffPositionEventStatusDescriptor.xml
+++ b/Descriptors/OpenStaffPositionEventStatusDescriptor.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<OpenStaffPositionEventStatusDescriptor>
+		<CodeValue>Approved</CodeValue>
+		<ShortDescription>Approved</ShortDescription>
+		<Description>Approved</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventStatusDescriptor</Namespace>
+	</OpenStaffPositionEventStatusDescriptor>
+	<OpenStaffPositionEventStatusDescriptor>
+		<CodeValue>Pending</CodeValue>
+		<ShortDescription>Pending</ShortDescription>
+		<Description>Pending</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventStatusDescriptor</Namespace>
+	</OpenStaffPositionEventStatusDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/OpenStaffPositionEventStatusDescriptor.xml
+++ b/Descriptors/OpenStaffPositionEventStatusDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<OpenStaffPositionEventStatusDescriptor>
 		<CodeValue>Approved</CodeValue>
 		<ShortDescription>Approved</ShortDescription>

--- a/Descriptors/OpenStaffPositionEventTypeDescriptor.xml
+++ b/Descriptors/OpenStaffPositionEventTypeDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<OpenStaffPositionEventTypeDescriptor>
 		<CodeValue>Closed</CodeValue>
 		<ShortDescription>Closed</ShortDescription>

--- a/Descriptors/OpenStaffPositionEventTypeDescriptor.xml
+++ b/Descriptors/OpenStaffPositionEventTypeDescriptor.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Closed</CodeValue>
+		<ShortDescription>Closed</ShortDescription>
+		<Description>Closed without being filled by a candidate</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+	<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Declared</CodeValue>
+		<ShortDescription>Declared</ShortDescription>
+		<Description>Need has been identified but the request has not been funded and approved</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+		<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Filled - forced placement</CodeValue>
+		<ShortDescription>Filled - forced placement</ShortDescription>
+		<Description>Filled by a candidate by forced placement</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+	<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Filled - mutual consent</CodeValue>
+		<ShortDescription>Filled - mutual consent</ShortDescription>
+		<Description>Filled by a candidate with mutual consent</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+	<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Posted</CodeValue>
+		<ShortDescription>Posted</ShortDescription>
+		<Description>The vacancy request has been funded and approved</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+	<OpenStaffPositionEventTypeDescriptor>
+		<CodeValue>Withdrawn</CodeValue>
+		<ShortDescription>Withdrawn</ShortDescription>
+		<Description>Withdrawn</Description>
+		<Namespace>uri://ed-fi.org/OpenStaffPositionEventTypeDescriptor</Namespace>
+	</OpenStaffPositionEventTypeDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/PreviousCareerDescriptor.xml
+++ b/Descriptors/PreviousCareerDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<PreviousCareerDescriptor>
 		<CodeValue>Accounting</CodeValue>
 		<ShortDescription>Accounting</ShortDescription>

--- a/Descriptors/PreviousCareerDescriptor.xml
+++ b/Descriptors/PreviousCareerDescriptor.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<PreviousCareerDescriptor>
+		<CodeValue>Accounting</CodeValue>
+		<ShortDescription>Accounting</ShortDescription>
+		<Description>Accounting</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Consulting</CodeValue>
+		<ShortDescription>Consulting</ShortDescription>
+		<Description>Consulting</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Education</CodeValue>
+		<ShortDescription>Education</ShortDescription>
+		<Description>Education</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Maintenance</CodeValue>
+		<ShortDescription>Maintenance</ShortDescription>
+		<Description>Maintenance</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Medical</CodeValue>
+		<ShortDescription>Medical</ShortDescription>
+		<Description>Medical</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Science and Technology</CodeValue>
+		<ShortDescription>Science and Technology</ShortDescription>
+		<Description>Science and Technology</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+	<PreviousCareerDescriptor>
+		<CodeValue>Other</CodeValue>
+		<ShortDescription>Other</ShortDescription>
+		<Description>Other</Description>
+		<Namespace>uri://ed-fi.org/PreviousCareerDescriptor</Namespace>
+	</PreviousCareerDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/StaffToCandidateRelationshipDescriptor.xml
+++ b/Descriptors/StaffToCandidateRelationshipDescriptor.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+	<StaffToCandidateRelationshipDescriptor>
+		<CodeValue>Coordinating Teacher</CodeValue>
+		<ShortDescription>Coordinating Teacher</ShortDescription>
+		<Description>Coordinating Teacher</Description>
+		<Namespace>uri://ed-fi.org/StaffToCandidateRelationshipDescriptor</Namespace>
+	</StaffToCandidateRelationshipDescriptor>
+		<StaffToCandidateRelationshipDescriptor>
+		<CodeValue>Mentor</CodeValue>
+		<ShortDescription>Mentor</ShortDescription>
+		<Description>Mentor</Description>
+		<Namespace>uri://ed-fi.org/StaffToCandidateRelationshipDescriptor</Namespace>
+	</StaffToCandidateRelationshipDescriptor>
+	<StaffToCandidateRelationshipDescriptor>
+		<CodeValue>Supervising Principal</CodeValue>
+		<ShortDescription>Supervising Principal</ShortDescription>
+		<Description>Supervising Principal</Description>
+		<Namespace>uri://ed-fi.org/StaffToCandidateRelationshipDescriptor</Namespace>
+	</StaffToCandidateRelationshipDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/StaffToCandidateRelationshipDescriptor.xml
+++ b/Descriptors/StaffToCandidateRelationshipDescriptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/EXTENSION-Interchange-Descriptors-Extension.xsd">
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
 	<StaffToCandidateRelationshipDescriptor>
 		<CodeValue>Coordinating Teacher</CodeValue>
 		<ShortDescription>Coordinating Teacher</ShortDescription>


### PR DESCRIPTION
[DATASTD-2388] Move additional descriptors as indicated in the ticket, alphabetized, and kept "Other" as last option of a list.

[DATASTD-2388]: https://edfi.atlassian.net/browse/DATASTD-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ