### PR TITLE
[XSD Update] Update from Ed-Fi-Model's `351a8ef` commit

### DIFF
--- a/Schemas/Bulk/Ed-Fi-Core.xsd
+++ b/Schemas/Bulk/Ed-Fi-Core.xsd
@@ -29270,7 +29270,7 @@
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:maxLength value="100" />
+      <xs:maxLength value="255" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="BellScheduleName">
@@ -29551,7 +29551,7 @@
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:maxLength value="75" />
+      <xs:maxLength value="100" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="ContentStandardVersion">
@@ -29630,7 +29630,7 @@
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:maxLength value="100" />
+      <xs:maxLength value="120" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="CredentialEndorsement">
@@ -30080,7 +30080,7 @@
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:maxLength value="60" />
+      <xs:maxLength value="120" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="ImmunizationName">


### PR DESCRIPTION
The [351a8ef commit](https://github.com/Ed-Fi-Closed/Ed-Fi-Model/commit/351a8efcb189349ffd788e744f270c36457b8b84) got recently merged into the Ed-Fi-Model repository.
This PR brings the updated XSD files.