### PR TITLE
[Datastd-2473] Add "Economic Disadvantage" descriptor to StudentDemographic

### DIFF
--- a/Descriptors/EconomicDisadvantageDescriptor.xml
+++ b/Descriptors/EconomicDisadvantageDescriptor.xml
@@ -22,8 +22,7 @@
 		<CodeValue>Other Economic Disadvantage</CodeValue>
 		<ShortDescription>Other Economic Disadvantage</ShortDescription>
 		<Description>Other Economic Disadvantage, Including:
-
-a) from a family with an annual income at or below the official federal poverty line, b) eligible for Temporary Assistance to Needy Families (TANF) or other public assistance, c) received a comparable state program of need-based financial assistance, d) eligible for programs assisted under Title II of the Job Training Partnership Act (JTPA), or e) eligible for benefits under the Food Stamp Act of 1977</Description>
+			a) from a family with an annual income at or below the official federal poverty line, b) eligible for Temporary Assistance to Needy Families (TANF) or other public assistance, c) received a comparable state program of need-based financial assistance, d) eligible for programs assisted under Title II of the Job Training Partnership Act (JTPA), or e) eligible for benefits under the Food Stamp Act of 1977</Description>
 		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
 	</EconomicDisadvantageDescriptor>
 	<EconomicDisadvantageDescriptor>

--- a/Descriptors/EconomicDisadvantageDescriptor.xml
+++ b/Descriptors/EconomicDisadvantageDescriptor.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterchangeDescriptors xmlns="http://ed-fi.org/6.0.0" xmlns:ann="http://ed-fi.org/annotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ed-fi.org/6.0.0 ../Schemas/Bulk/Interchange-Descriptors.xsd">
+	<EconomicDisadvantageDescriptor>
+		<CodeValue>Not Qualified As Economically Disadvantaged</CodeValue>
+		<ShortDescription>Did Not Qualified As Economically Disadvantaged</ShortDescription>
+		<Description>Did Not Qualified As Economically Disadvantaged</Description>
+		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
+	</EconomicDisadvantageDescriptor>
+	<EconomicDisadvantageDescriptor>
+		<CodeValue>Eligible For Free Meals</CodeValue>
+		<ShortDescription>Eligible For Free Meals</ShortDescription>
+		<Description>Under The National School Lunch And Child Nutrition Program</Description>
+		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
+	</EconomicDisadvantageDescriptor>
+	<EconomicDisadvantageDescriptor>
+		<CodeValue>Eligible for Reduced-Price Meals</CodeValue>
+		<ShortDescription>Eligible for Reduced-Price Meals</ShortDescription>
+		<Description>Eligible For Reduced-price Meals Under The National School Lunch And Child Nutrition Program</Description>
+		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
+	</EconomicDisadvantageDescriptor>
+	<EconomicDisadvantageDescriptor>
+		<CodeValue>Other Economic Disadvantage</CodeValue>
+		<ShortDescription>Other Economic Disadvantage</ShortDescription>
+		<Description>Other Economic Disadvantage, Including:
+
+a) from a family with an annual income at or below the official federal poverty line, b) eligible for Temporary Assistance to Needy Families (TANF) or other public assistance, c) received a comparable state program of need-based financial assistance, d) eligible for programs assisted under Title II of the Job Training Partnership Act (JTPA), or e) eligible for benefits under the Food Stamp Act of 1977</Description>
+		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
+	</EconomicDisadvantageDescriptor>
+	<EconomicDisadvantageDescriptor>
+		<CodeValue>Unknown</CodeValue>
+		<ShortDescription>Unknown</ShortDescription>
+		<Description>The Economic Disadvantage status is unknown</Description>
+		<Namespace>uri://ed-fi.org/EconomicDisadvantageDescriptor</Namespace>
+	</EconomicDisadvantageDescriptor>
+</InterchangeDescriptors>

--- a/Descriptors/StudentCharacteristicDescriptor.xml
+++ b/Descriptors/StudentCharacteristicDescriptor.xml
@@ -78,10 +78,4 @@
 		<Description>Displaced</Description>
 		<Namespace>uri://ed-fi.org/StudentCharacteristicDescriptor</Namespace>
 	</StudentCharacteristicDescriptor>
-	<StudentCharacteristicDescriptor>
-		<CodeValue>Economic Disadvantaged</CodeValue>
-		<ShortDescription>Economic Disadvantaged</ShortDescription>
-		<Description>Economic Disadvantaged</Description>
-		<Namespace>uri://ed-fi.org/StudentCharacteristicDescriptor</Namespace>
-	</StudentCharacteristicDescriptor>
 </InterchangeDescriptors>

--- a/Descriptors/StudentCharacteristicDescriptor.xml
+++ b/Descriptors/StudentCharacteristicDescriptor.xml
@@ -78,4 +78,10 @@
 		<Description>Displaced</Description>
 		<Namespace>uri://ed-fi.org/StudentCharacteristicDescriptor</Namespace>
 	</StudentCharacteristicDescriptor>
+	<StudentCharacteristicDescriptor>
+		<CodeValue>Economic Disadvantaged</CodeValue>
+		<ShortDescription>DEPRECATED: Economic Disadvantaged</ShortDescription>
+		<Description>DEPRECATED: Economic Disadvantaged</Description>
+		<Namespace>uri://ed-fi.org/StudentCharacteristicDescriptor</Namespace>
+	</StudentCharacteristicDescriptor>
 </InterchangeDescriptors>

--- a/Samples/Sample XML/Student.xml
+++ b/Samples/Sample XML/Student.xml
@@ -11151,6 +11151,7 @@
 		<Disability>
 			<Disability>uri://ed-fi.org/DisabilityDescriptor#Autism Spectrum Disorders</Disability>
 		</Disability>
+		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Other Economic Disadvantage</EconomicDisadvantage>
 		<GenderIdentity>Male</GenderIdentity>
 		<HispanicLatinoEthnicity>1</HispanicLatinoEthnicity>
 		<Language>
@@ -11181,6 +11182,7 @@
 			<Citizenship>
 			<CitizenshipStatus>uri://ed-fi.org/CitizenshipStatusDescriptor#Refugee</CitizenshipStatus>
 		</Citizenship>
+		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Not Qualified As Economically Disadvantaged</EconomicDisadvantage>
 		<GenderIdentity>Female</GenderIdentity>
 		<HispanicLatinoEthnicity>0</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#Middle Eastern or North African</Race>
@@ -11205,6 +11207,7 @@
 		<Disability>
 			<Disability>uri://ed-fi.org/DisabilityDescriptor#Orthopedic Impairment</Disability>
 		</Disability>
+		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Eligible for Reduced-Price Meals</EconomicDisadvantage>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#eng</Language>
 			<LanguageUse>uri://ed-fi.org/LanguageUseDescriptor#Home language</LanguageUse>
@@ -11228,6 +11231,7 @@
 		<Disability>
 			<Disability>uri://ed-fi.org/DisabilityDescriptor#Other</Disability>
 		</Disability>
+		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Eligible for Free Meals</EconomicDisadvantage>
 		<GenderIdentity>Female</GenderIdentity>
 		<HispanicLatinoEthnicity>0</HispanicLatinoEthnicity>
 		<Language>

--- a/Samples/Sample XML/Student.xml
+++ b/Samples/Sample XML/Student.xml
@@ -11231,7 +11231,7 @@
 		<Disability>
 			<Disability>uri://ed-fi.org/DisabilityDescriptor#Other</Disability>
 		</Disability>
-		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Eligible for Free Meals</EconomicDisadvantage>
+		<EconomicDisadvantage>uri://ed-fi.org/EconomicDisadvantageDescriptor#Eligible For Free Meals</EconomicDisadvantage>
 		<GenderIdentity>Female</GenderIdentity>
 		<HispanicLatinoEthnicity>0</HispanicLatinoEthnicity>
 		<Language>

--- a/Samples/Sample XML/StudentEnrollment.xml
+++ b/Samples/Sample XML/StudentEnrollment.xml
@@ -515274,7 +515274,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#tur</Language>
@@ -520134,7 +520134,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#rum</Language>
@@ -521282,7 +521282,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -527822,7 +527822,7 @@
 		<HispanicLatinoEthnicity>false</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#Choose Not to Respond</Race>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -527903,7 +527903,7 @@
 		<HispanicLatinoEthnicity>false</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#American Indian or Alaska Native</Race>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -528932,7 +528932,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Parent in Military</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -530515,7 +530515,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Parent in Military</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -532449,7 +532449,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Parent in Military</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#sin</Language>
@@ -532908,7 +532908,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Parent in Military</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#kor</Language>
@@ -535182,7 +535182,7 @@
 		<HispanicLatinoEthnicity>false</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#American Indian or Alaska Native</Race>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -536172,7 +536172,7 @@
 		<HispanicLatinoEthnicity>true</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#Hispanic or Latino</Race>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#urd</Language>
@@ -543387,7 +543387,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorName>At Risk</IndicatorName>
@@ -544888,7 +544888,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#heb</Language>
@@ -545870,7 +545870,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -548246,7 +548246,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Homeless</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -552838,7 +552838,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Foster Care</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -555752,7 +555752,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#kmb</Language>
@@ -558402,7 +558402,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Runaway</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -558860,7 +558860,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Immigrant</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#hun</Language>
@@ -566056,7 +566056,7 @@
 		<HispanicLatinoEthnicity>false</HispanicLatinoEthnicity>
 		<Race>uri://ed-fi.org/RaceDescriptor#Hispanic or Latino</Race>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentIndicator>
 			<IndicatorGroup>Digital Equity</IndicatorGroup>
@@ -572852,7 +572852,7 @@
 			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Parent in Military</StudentCharacteristic>
 		</StudentCharacteristic>
 		<StudentCharacteristic>
-			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Economic Disadvantaged</StudentCharacteristic>
+			<StudentCharacteristic>uri://ed-fi.org/StudentCharacteristicDescriptor#Other</StudentCharacteristic>
 		</StudentCharacteristic>
 		<Language>
 			<Language>uri://ed-fi.org/LanguageDescriptor#sin</Language>


### PR DESCRIPTION
Added new descriptor XML file and associated values.

Ticket advises to deprecate the existing value on the StudentCharacteristic. Given that I understood these values to be examples of the types of data we're expecting it feels like deprecation can be updated to simply remove the value that's no longer applicable from the XML file. Requesting review and advise.