### PR TITLE
DATASTD-2514 Sample data has typo in some descriptor namespaces

### DIFF
--- a/Descriptors/CertificationExamTypeDescriptor.xml
+++ b/Descriptors/CertificationExamTypeDescriptor.xml
@@ -4,18 +4,18 @@
 		<CodeValue>National</CodeValue>
 		<ShortDescription>Exam is for a nationally recognized certification.</ShortDescription>
 		<Description>The exam is for a nationally recognized certification.</Description>
-		<Namespace>uri://edfi.org/CertificationExamTypeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationExamTypeDescriptor</Namespace>
 	</CertificationExamTypeDescriptor>
 	<CertificationExamTypeDescriptor>
 		<CodeValue>Other</CodeValue>
 		<ShortDescription>Exam for other level of recognition.</ShortDescription>
 		<Description>A certification exam for recognition other than state or national level.</Description>
-		<Namespace>uri://edfi.org/CertificationExamTypeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationExamTypeDescriptor</Namespace>
 	</CertificationExamTypeDescriptor>
 	<CertificationExamTypeDescriptor>
 		<CodeValue>State</CodeValue>
 		<ShortDescription>Exam is for a state-wide recognized certification.</ShortDescription>
 		<Description>The exam is for a state-wide recognized certification.</Description>
-		<Namespace>uri://edfi.org/CertificationExamTypeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationExamTypeDescriptor</Namespace>
 	</CertificationExamTypeDescriptor>	
 </InterchangeDescriptors>

--- a/Descriptors/CertificationLevelDescriptor.xml
+++ b/Descriptors/CertificationLevelDescriptor.xml
@@ -4,48 +4,48 @@
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>Certifies for administrative responsibilities.</ShortDescription>
 		<Description>Certification permits the educator for responsibilities at administrative level.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>All-Level</CodeValue>
 		<ShortDescription>For instructional responsibilities at all-level.</ShortDescription>
 		<Description>Certification permits the educator for instructional responsibilities at all-level.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Elementary</CodeValue>
 		<ShortDescription>For elementary school instructional certification.</ShortDescription>
 		<Description>Certification permits the educator for instructional responsibilities at elementary school level.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Middle School</CodeValue>
 		<ShortDescription>For middle school instructional responsibilities.</ShortDescription>
 		<Description>Certification permits the educator for instructional responsibilities at middle school level.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Secondary</CodeValue>
 		<ShortDescription>For secondary school instructional certification.</ShortDescription>
 		<Description>Certification permits the educator for instructional responsibilities at secondary school level.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Student Services</CodeValue>
 		<ShortDescription>For student service related responsibilities.</ShortDescription>
 		<Description>Certification permits the educator for student service related responsibilities.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Supplemental</CodeValue>
 		<ShortDescription>For supplemental instructional responsibilities.</ShortDescription>
 		<Description>Certification permits the educator for supplemental instructional responsibilities.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>
 	<CertificationLevelDescriptor>
 		<CodeValue>Teacher Foundations</CodeValue>
 		<ShortDescription>For teacher foundational responsibilities.</ShortDescription>
 		<Description>Certification permits the educator for teacher foundational responsibilities.</Description>
-		<Namespace>uri://edfi.org/CertificationLevelDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationLevelDescriptor</Namespace>
 	</CertificationLevelDescriptor>	
 </InterchangeDescriptors>

--- a/Descriptors/CertificationRouteDescriptor.xml
+++ b/Descriptors/CertificationRouteDescriptor.xml
@@ -4,66 +4,66 @@
 		<CodeValue>Alternative Program</CodeValue>
 		<ShortDescription>Certified by an alternative program.</ShortDescription>
 		<Description>The educator has attained an alternative program to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Center Professional Development</CodeValue>
 		<ShortDescription>Certified by a professional development.</ShortDescription>
 		<Description>The educator has attained a professional development center to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Certification by Exam</CodeValue>
 		<ShortDescription>The educator has certified by taking an exam.</ShortDescription>
 		<Description>The educator has certified by taking an exam.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>		
 	<CertificationRouteDescriptor>
 		<CodeValue>Out of State</CodeValue>
 		<ShortDescription>The educator has certified out of state.</ShortDescription>
 		<Description>The educator has certified out of state.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Paraprofessional Program</CodeValue>
 		<ShortDescription>Certified by a paraprofessional program.</ShortDescription>
 		<Description>The educator has completed a paraprofessional program to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Permit Program</CodeValue>
 		<ShortDescription>Certified by a permit program.</ShortDescription>
 		<Description>The educator has attained a permit program to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Post-Baccalaureate</CodeValue>
 		<ShortDescription>Certified by a post-baccalaureate degree.</ShortDescription>
 		<Description>The educator has completed a post-baccalaureate degree to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>	
 	<CertificationRouteDescriptor>
 		<CodeValue>Standard Program</CodeValue>
 		<ShortDescription>Certified by a standard program.</ShortDescription>
 		<Description>The educator has attained a standard program to be certified.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Temporary Teaching Certificate</CodeValue>
 		<ShortDescription>The educator has a temporary teaching certificate.</ShortDescription>
 		<Description>The educator has obtained a temporary teaching certificate.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 	<CertificationRouteDescriptor>
 		<CodeValue>Unknown</CodeValue>
 		<ShortDescription>The route for certification is unknown.</ShortDescription>
 		<Description>The route the educator followed for certification is unknown.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>	
 	<CertificationRouteDescriptor>
 		<CodeValue>Vocational Experience</CodeValue>
 		<ShortDescription>Certified by a vocational experience.</ShortDescription>
 		<Description>The educator has obtained certification through a vocational experience.</Description>
-		<Namespace>uri://edfi.org/CertificationRouteDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CertificationRouteDescriptor</Namespace>
 	</CertificationRouteDescriptor>
 </InterchangeDescriptors>

--- a/Descriptors/CredentialStatusDescriptor.xml
+++ b/Descriptors/CredentialStatusDescriptor.xml
@@ -4,48 +4,48 @@
 		<CodeValue>Active</CodeValue>
 		<ShortDescription>The credential status is Active.</ShortDescription>
 		<Description>The credential of the person is currently Active</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Deprecated</CodeValue>
 		<ShortDescription>The credential status is Deprecated.</ShortDescription>
 		<Description>The credential of the person is currently Deprecated</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Expired</CodeValue>
 		<ShortDescription>The credential status is Expired.</ShortDescription>
 		<Description>The credential of the person is currently Expired</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Renewed</CodeValue>
 		<ShortDescription>The credential status is Renewed.</ShortDescription>
 		<Description>The credential of the person is currently Renewed</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Retired</CodeValue>
 		<ShortDescription>The credential status is Retired.</ShortDescription>
 		<Description>The credential of the person is currently Retired</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Revoked</CodeValue>
 		<ShortDescription>The credential status is Revoked.</ShortDescription>
 		<Description>The credential of the person is currently Revoked</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>
 	<CredentialStatusDescriptor>
 		<CodeValue>Suspended</CodeValue>
 		<ShortDescription>The credential status is Suspended.</ShortDescription>
 		<Description>The credential of the person is currently Suspended</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>	
 	<CredentialStatusDescriptor>
 		<CodeValue>Voluntary Surrender</CodeValue>
 		<ShortDescription>The credential status is Voluntary Surrendered.</ShortDescription>
 		<Description>The credential of the person is currently Voluntary Surrendered</Description>
-		<Namespace>uri://edfi.org/CredentialStatusDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/CredentialStatusDescriptor</Namespace>
 	</CredentialStatusDescriptor>			
 </InterchangeDescriptors>

--- a/Descriptors/DegreeDescriptor.xml
+++ b/Descriptors/DegreeDescriptor.xml
@@ -4,36 +4,36 @@
 		<CodeValue>Associate's degree</CodeValue>
 		<ShortDescription>Certification requires  an Associate's degree.</ShortDescription>
 		<Description>The certification requires at minimum an Associate's degree.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>
 	<DegreeDescriptor>
 		<CodeValue>Bachelor's degree</CodeValue>
 		<ShortDescription>Certification requires  a Bachelor's degree.</ShortDescription>
 		<Description>The certification requires at minimum a Bachelor's degree.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>
 	<DegreeDescriptor>
 		<CodeValue>Doctorate degree</CodeValue>
 		<ShortDescription>Certification requires  a Doctorate degree.</ShortDescription>
 		<Description>The certification requires at minimum a Doctorate degree.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>
 	<DegreeDescriptor>
 		<CodeValue>High school diploma</CodeValue>
 		<ShortDescription>Certification requires  a High school diploma.</ShortDescription>
 		<Description>The certification requires at minimum a High school diploma.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>	
 	<DegreeDescriptor>
 		<CodeValue>Master's degree</CodeValue>
 		<ShortDescription>Certification requires  a Master's degree.</ShortDescription>
 		<Description>The certification requires at minimum a Master's degree.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>
 	<DegreeDescriptor>
 		<CodeValue>No degree required</CodeValue>
 		<ShortDescription>Certification doesn't have a degree requirement.</ShortDescription>
 		<Description>The certification doesn't have a degree requirement.</Description>
-		<Namespace>uri://edfi.org/DegreeDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/DegreeDescriptor</Namespace>
 	</DegreeDescriptor>	
 </InterchangeDescriptors>

--- a/Descriptors/EducatorRoleDescriptor.xml
+++ b/Descriptors/EducatorRoleDescriptor.xml
@@ -4,114 +4,114 @@
 		<CodeValue>Administrative</CodeValue>
 		<ShortDescription>The educator is an Administrative.</ShortDescription>
 		<Description>The educator is an Administrative.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Assistant Principal</CodeValue>
 		<ShortDescription>The educator is an Assistant Principal.</ShortDescription>
 		<Description>The educator is an Assistant Principal.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Associate School Psychologist</CodeValue>
 		<ShortDescription>The educator is an Associate School Psychologist.</ShortDescription>
 		<Description>The educator is an Associate School Psychologist.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Counselor</CodeValue>
 		<ShortDescription>The educator is a Counselor.</ShortDescription>
 		<Description>The educator is a Counselor.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>	
 	<EducatorRoleDescriptor>
 		<CodeValue>Educational Aide</CodeValue>
 		<ShortDescription>The educator is an Educational Aide.</ShortDescription>
 		<Description>The educator is an Educational Aide.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Educational Diagnostician</CodeValue>
 		<ShortDescription>The educator is an Educational Diagnostician.</ShortDescription>
 		<Description>The educator is an Educational Diagnostician.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Educational Secretary</CodeValue>
 		<ShortDescription>The educator is an Educational Secretary.</ShortDescription>
 		<Description>The educator is an Educational Secretary.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Generalist</CodeValue>
 		<ShortDescription>The educator is a Generalist.</ShortDescription>
 		<Description>The educator is a Generalist.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Instructional Officer</CodeValue>
 		<ShortDescription>The educator is an Instructional Officer.</ShortDescription>
 		<Description>The educator is an Instructional Officer.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Librarian</CodeValue>
 		<ShortDescription>The educator is a Librarian.</ShortDescription>
 		<Description>The educator is a Librarian.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Physician</CodeValue>
 		<ShortDescription>The educator is a Physician.</ShortDescription>
 		<Description>The educator is a Physician.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Principal</CodeValue>
 		<ShortDescription>The educator is a Principal.</ShortDescription>
 		<Description>The educator is a Principal.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>School Nurse</CodeValue>
 		<ShortDescription>The educator is a School Nurse.</ShortDescription>
 		<Description>The educator is a School Nurse.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>School Psychologist</CodeValue>
 		<ShortDescription>The educator is a School Psychologist.</ShortDescription>
 		<Description>The educator is a School Psychologist.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Special Education</CodeValue>
 		<ShortDescription>The educator is a Special Education.</ShortDescription>
 		<Description>The educator is a Special Education.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Superintendent</CodeValue>
 		<ShortDescription>The educator is a Superintendent.</ShortDescription>
 		<Description>The educator is a Superintendent.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>	
 	<EducatorRoleDescriptor>
 		<CodeValue>Teacher</CodeValue>
 		<ShortDescription>The educator is a Teacher.</ShortDescription>
 		<Description>The educator is a Teacher.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Teacher Supervisor</CodeValue>
 		<ShortDescription>The educator is a Teacher Supervisor.</ShortDescription>
 		<Description>The educator is a Teacher Supervisor.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>
 	<EducatorRoleDescriptor>
 		<CodeValue>Visiting Teacher</CodeValue>
 		<ShortDescription>The educator is a Visiting Teacher.</ShortDescription>
 		<Description>The educator is a Visiting Teacher.</Description>
-		<Namespace>uri://edfi.org/EducatorRoleDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/EducatorRoleDescriptor</Namespace>
 	</EducatorRoleDescriptor>	
 </InterchangeDescriptors>

--- a/Descriptors/InstructionalSettingDescriptor.xml
+++ b/Descriptors/InstructionalSettingDescriptor.xml
@@ -4,30 +4,30 @@
 		<CodeValue>Classroom</CodeValue>
 		<ShortDescription>An instruction in Classroom setting is authorized.</ShortDescription>
 		<Description>The certification authorize the instruction to be delivered in Classroom setting.</Description>
-		<Namespace>uri://edfi.org/InstructionalSettingDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/InstructionalSettingDescriptor</Namespace>
 	</InstructionalSettingDescriptor>
 	<InstructionalSettingDescriptor>
 		<CodeValue>Co-Op</CodeValue>
 		<ShortDescription>An instruction in Co-op setting authorized.</ShortDescription>
 		<Description>The certification authorize the instruction to be delivered in Co-op setting.</Description>
-		<Namespace>uri://edfi.org/InstructionalSettingDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/InstructionalSettingDescriptor</Namespace>
 	</InstructionalSettingDescriptor>
 	<InstructionalSettingDescriptor>
 		<CodeValue>Regular</CodeValue>
 		<ShortDescription>An instruction in Regular setting authorized.</ShortDescription>
 		<Description>The certification authorize the instruction to be delivered in Regular setting.</Description>
-		<Namespace>uri://edfi.org/InstructionalSettingDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/InstructionalSettingDescriptor</Namespace>
 	</InstructionalSettingDescriptor>
 	<InstructionalSettingDescriptor>
 		<CodeValue>Virtual</CodeValue>
 		<ShortDescription>An instruction in Virtual setting authorized.</ShortDescription>
 		<Description>The certification authorize the instruction to be delivered in Virtual setting.</Description>
-		<Namespace>uri://edfi.org/InstructionalSettingDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/InstructionalSettingDescriptor</Namespace>
 	</InstructionalSettingDescriptor>
 	<InstructionalSettingDescriptor>
 		<CodeValue>Vocational Experience</CodeValue>
 		<ShortDescription>Instruction in Vocational  setting authorized.</ShortDescription>
 		<Description>The certification authorize the instruction to be delivered in Vocational Experience setting.</Description>
-		<Namespace>uri://edfi.org/InstructionalSettingDescriptor</Namespace>
+		<Namespace>uri://ed-fi.org/InstructionalSettingDescriptor</Namespace>
 	</InstructionalSettingDescriptor>
 </InterchangeDescriptors>


### PR DESCRIPTION
Added hypens to entries in the descriptor file that had "edfi.org" instead of "ed-fi.org" as part of their namespace values. 

Did a cursory search over the /Samples directory for edfi.org and it doesn't appear as though there are sample data values that need to be changed.