### PR TITLE
DATASTD-2523 Spell out state names in the state abbreviation descriptor

### DIFF
--- a/Descriptors/StateAbbreviationDescriptor.xml
+++ b/Descriptors/StateAbbreviationDescriptor.xml
@@ -3,373 +3,373 @@
 	<StateAbbreviationDescriptor>
 		<CodeValue>AA</CodeValue>
 		<ShortDescription>AA</ShortDescription>
-		<Description>AA</Description>
+		<Description>Armed Forces Americas</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AE</CodeValue>
 		<ShortDescription>AE</ShortDescription>
-		<Description>AE</Description>
+		<Description>Armed Forces Europe, Middle East, Canada, Africa</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AK</CodeValue>
 		<ShortDescription>AK</ShortDescription>
-		<Description>AK</Description>
+		<Description>Alaska</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AL</CodeValue>
 		<ShortDescription>AL</ShortDescription>
-		<Description>AL</Description>
+		<Description>Alabama</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AP</CodeValue>
 		<ShortDescription>AP</ShortDescription>
-		<Description>AP</Description>
+		<Description>Armed Forces Pacific</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AR</CodeValue>
 		<ShortDescription>AR</ShortDescription>
-		<Description>AR</Description>
+		<Description>Arkansas</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AS</CodeValue>
 		<ShortDescription>AS</ShortDescription>
-		<Description>AS</Description>
+		<Description>American Samoa</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>AZ</CodeValue>
 		<ShortDescription>AZ</ShortDescription>
-		<Description>AZ</Description>
+		<Description>Arizona</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>CA</CodeValue>
 		<ShortDescription>CA</ShortDescription>
-		<Description>CA</Description>
+		<Description>California</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>CO</CodeValue>
 		<ShortDescription>CO</ShortDescription>
-		<Description>CO</Description>
+		<Description>Colorado</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>CT</CodeValue>
 		<ShortDescription>CT</ShortDescription>
-		<Description>CT</Description>
+		<Description>Connecticut</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>DC</CodeValue>
 		<ShortDescription>DC</ShortDescription>
-		<Description>DC</Description>
+		<Description>District of Columbia</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>DE</CodeValue>
 		<ShortDescription>DE</ShortDescription>
-		<Description>DE</Description>
+		<Description>Delaware</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>FL</CodeValue>
 		<ShortDescription>FL</ShortDescription>
-		<Description>FL</Description>
+		<Description>Florida</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>FM</CodeValue>
 		<ShortDescription>FM</ShortDescription>
-		<Description>FM</Description>
+		<Description>Federated States of Micronesia</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>GA</CodeValue>
 		<ShortDescription>GA</ShortDescription>
-		<Description>GA</Description>
+		<Description>Georgia</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>GU</CodeValue>
 		<ShortDescription>GU</ShortDescription>
-		<Description>GU</Description>
+		<Description>Guam</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>HI</CodeValue>
 		<ShortDescription>HI</ShortDescription>
-		<Description>HI</Description>
+		<Description>Hawaii</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>IA</CodeValue>
 		<ShortDescription>IA</ShortDescription>
-		<Description>IA</Description>
+		<Description>Iowa</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>ID</CodeValue>
 		<ShortDescription>ID</ShortDescription>
-		<Description>ID</Description>
+		<Description>Idaho</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>IL</CodeValue>
 		<ShortDescription>IL</ShortDescription>
-		<Description>IL</Description>
+		<Description>Illinois</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>IN</CodeValue>
 		<ShortDescription>IN</ShortDescription>
-		<Description>IN</Description>
+		<Description>Indiana</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>KS</CodeValue>
 		<ShortDescription>KS</ShortDescription>
-		<Description>KS</Description>
+		<Description>Kansas</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>KY</CodeValue>
 		<ShortDescription>KY</ShortDescription>
-		<Description>KY</Description>
+		<Description>Kentucky</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>LA</CodeValue>
 		<ShortDescription>LA</ShortDescription>
-		<Description>LA</Description>
+		<Description>Louisiana</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MA</CodeValue>
 		<ShortDescription>MA</ShortDescription>
-		<Description>MA</Description>
+		<Description>Massachusetts</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MD</CodeValue>
 		<ShortDescription>MD</ShortDescription>
-		<Description>MD</Description>
+		<Description>Maryland</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>ME</CodeValue>
 		<ShortDescription>ME</ShortDescription>
-		<Description>ME</Description>
+		<Description>Maine</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MH</CodeValue>
 		<ShortDescription>MH</ShortDescription>
-		<Description>MH</Description>
+		<Description>Marshall Islands</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MI</CodeValue>
 		<ShortDescription>MI</ShortDescription>
-		<Description>MI</Description>
+		<Description>Michigan</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MN</CodeValue>
 		<ShortDescription>MN</ShortDescription>
-		<Description>MN</Description>
+		<Description>Minnesota</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MO</CodeValue>
 		<ShortDescription>MO</ShortDescription>
-		<Description>MO</Description>
+		<Description>Missouri</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MP</CodeValue>
 		<ShortDescription>MP</ShortDescription>
-		<Description>MP</Description>
+		<Description>Northern Mariana Islands</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MS</CodeValue>
 		<ShortDescription>MS</ShortDescription>
-		<Description>MS</Description>
+		<Description>Mississippi</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>MT</CodeValue>
 		<ShortDescription>MT</ShortDescription>
-		<Description>MT</Description>
+		<Description>Montana</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NC</CodeValue>
 		<ShortDescription>NC</ShortDescription>
-		<Description>NC</Description>
+		<Description>North Carolina</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>ND</CodeValue>
 		<ShortDescription>ND</ShortDescription>
-		<Description>ND</Description>
+		<Description>North Dakota</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NE</CodeValue>
 		<ShortDescription>NE</ShortDescription>
-		<Description>NE</Description>
+		<Description>Nebraska</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NH</CodeValue>
 		<ShortDescription>NH</ShortDescription>
-		<Description>NH</Description>
+		<Description>New Hampshire</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NJ</CodeValue>
 		<ShortDescription>NJ</ShortDescription>
-		<Description>NJ</Description>
+		<Description>New Jersey</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NM</CodeValue>
 		<ShortDescription>NM</ShortDescription>
-		<Description>NM</Description>
+		<Description>New Mexico</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NV</CodeValue>
 		<ShortDescription>NV</ShortDescription>
-		<Description>NV</Description>
+		<Description>Nevada</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>NY</CodeValue>
 		<ShortDescription>NY</ShortDescription>
-		<Description>NY</Description>
+		<Description>New York</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>OH</CodeValue>
 		<ShortDescription>OH</ShortDescription>
-		<Description>OH</Description>
+		<Description>Ohio</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>OK</CodeValue>
 		<ShortDescription>OK</ShortDescription>
-		<Description>OK</Description>
+		<Description>Oklahoma</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>OR</CodeValue>
 		<ShortDescription>OR</ShortDescription>
-		<Description>OR</Description>
+		<Description>Oregon</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>PA</CodeValue>
 		<ShortDescription>PA</ShortDescription>
-		<Description>PA</Description>
+		<Description>Pennsylvania</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>PR</CodeValue>
 		<ShortDescription>PR</ShortDescription>
-		<Description>PR</Description>
+		<Description>Puerto Rico</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>PW</CodeValue>
 		<ShortDescription>PW</ShortDescription>
-		<Description>PW</Description>
+		<Description>Palau</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>RI</CodeValue>
 		<ShortDescription>RI</ShortDescription>
-		<Description>RI</Description>
+		<Description>Rhode Island</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>SC</CodeValue>
 		<ShortDescription>SC</ShortDescription>
-		<Description>SC</Description>
+		<Description>South Carolina</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>SD</CodeValue>
 		<ShortDescription>SD</ShortDescription>
-		<Description>SD</Description>
+		<Description>South Dakota</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>TN</CodeValue>
 		<ShortDescription>TN</ShortDescription>
-		<Description>TN</Description>
+		<Description>Tennessee</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>TX</CodeValue>
 		<ShortDescription>TX</ShortDescription>
-		<Description>TX</Description>
+		<Description>Texas</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>UT</CodeValue>
 		<ShortDescription>UT</ShortDescription>
-		<Description>UT</Description>
+		<Description>Utah</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>VA</CodeValue>
 		<ShortDescription>VA</ShortDescription>
-		<Description>VA</Description>
+		<Description>Virginia</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>VI</CodeValue>
 		<ShortDescription>VI</ShortDescription>
-		<Description>VI</Description>
+		<Description>United States Virgin Islands</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>VT</CodeValue>
 		<ShortDescription>VT</ShortDescription>
-		<Description>VT</Description>
+		<Description>Vermont</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>WA</CodeValue>
 		<ShortDescription>WA</ShortDescription>
-		<Description>WA</Description>
+		<Description>Washington</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>WI</CodeValue>
 		<ShortDescription>WI</ShortDescription>
-		<Description>WI</Description>
+		<Description>Wisconsin</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>WV</CodeValue>
 		<ShortDescription>WV</ShortDescription>
-		<Description>WV</Description>
+		<Description>West Virginia</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 	<StateAbbreviationDescriptor>
 		<CodeValue>WY</CodeValue>
 		<ShortDescription>WY</ShortDescription>
-		<Description>WY</Description>
+		<Description>Wyoming</Description>
 		<Namespace>uri://ed-fi.org/StateAbbreviationDescriptor</Namespace>
 	</StateAbbreviationDescriptor>
 </InterchangeDescriptors>


### PR DESCRIPTION
Replaced description value for US States and Territories with full name of the abbreviated/code value.